### PR TITLE
GUACAMOLE-243: Correct XML structure of "ldap-operation-timeout" property.

### DIFF
--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -427,9 +427,10 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
                 </varlistentry>
                 <varlistentry>
                     <term><property>ldap-operation-timeout</property></term>
-                        <para>This option sets the timeout, in seconds, of any single LDAP operation.  The default is 30 seconds.
-                        When this timeout is reached LDAP operations will be aborted.</para>
                     <listitem>
+                        <para>This option sets the timeout, in seconds, of any single LDAP
+                            operation. The default is 30 seconds. When this timeout is reached LDAP
+                            operations will be aborted.</para>
                     </listitem>
                 </varlistentry>
             </variablelist>


### PR DESCRIPTION
The documentation for the `ldap-operation-timeout` property added via #67 (part of [GUACAMOLE-243](https://issues.apache.org/jira/browse/GUACAMOLE-243)) contains an incorrectly-nested `<para>` which was clearly meant to be part of the empty `<listitem>` within the same `<varlistentry>`:

https://github.com/apache/guacamole-manual/blob/eab8ae3da4655e6677d44a81ddad982feb28d03f/src/chapters/ldap-auth.xml#L428-L435

The `<para>` just needs to be moved within the `<listitem>`.