### PR TITLE
GUACAMOLE-494: Remove documentation for deprecated properties.

### DIFF
--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -324,16 +324,9 @@ guacd-port:     4822</programlisting>
                 <primary>user-mapping.xml</primary>
             </indexterm>
             <para>The default authentication provider used by Guacamole reads all username,
-                password, and configuration information from a file called the "user mapping". By
-                default, Guacamole will look for this file at
-                    <filename>GUACAMOLE_HOME/user-mapping.xml</filename>, but this can be overridden
-                by specifying the location with the <property>user-mapping</property> property
-                within <filename>guacamole.properties</filename>:</para>
-            <informalexample>
-                <programlisting>user-mapping: <replaceable>/path/to/user-mapping.xml</replaceable></programlisting>
-            </informalexample>
-            <para>An example of a user mapping file is included with Guacamole, and looks something
-                like this:</para>
+                password, and configuration information from a file called the "user mapping"
+                located at <filename>GUACAMOLE_HOME/user-mapping.xml</filename>. An example of a
+                user mapping file is included with Guacamole, and looks something like this:</para>
             <programlisting>&lt;user-mapping>
 	
     &lt;!-- Per-user authentication and config information -->

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -682,22 +682,6 @@ postgresql-default-max-group-connections-per-user: 0
 sqlserver-default-max-connections-per-user: 0
 sqlserver-default-max-group-connections-per-user: 0</programlisting>
                 </informalexample>
-                <para>The above properties replace the "simultaneous" and "duplicate" properties used
-                    by prior Guacamole releases. The older properties will still work, but are now
-                    deprecated. If you continue to use those properties, you will receive warnings
-                    in the logs advising you of their deprecated status and including examples for
-                    providing the same behavior with the new properties described above:</para>
-                <informalexample>
-                    <screen><computeroutput>WARN  o.g.g.a.p.PostgreSQLAuthenticationProvider - The
-"postgresql-disallow-simultaneous-connections" property is deprecated.
-Use "postgresql-default-max-connections" and
-"postgresql-default-max-group-connections" instead.
-INFO  o.g.g.a.p.PostgreSQLAuthenticationProvider - To achieve the same
-result of setting "postgresql-disallow-simultaneous-connections" to
-"false", set "postgresql-default-max-connections" to "0" and
-"postgresql-default-max-group-connections" to "0".</computeroutput></screen>
-                </informalexample>
-                <para>These deprecated properties are not supported in the SQL Server module.</para>
                 <para>If you wish to impose an absolute limit on the number of connections that can
                     be established through Guacamole, ignoring which users or connections are
                     involved, this can be done as well. By default, Guacamole will impose no such


### PR DESCRIPTION
This change removes the documentation for the properties now being removed via apache/guacamole-client#239.