### PR TITLE
GUACAMOLE-639: Add installation of libtool

### DIFF
--- a/src/chapters/installing.xml
+++ b/src/chapters/installing.xml
@@ -198,6 +198,30 @@
                             </entry>
                         </row>
                         <row>
+                            <entry><link xl:href="https://www.gnu.org/software/libtool/manual/libtool.html"
+                                    >libtool</link></entry>
+                            <entry>
+                                <para>libtool is used during the build process. 
+                                libtool creates compiled libraries needed for Guacamole.</para>
+                                <informaltable frame="none" rowheader="firstcol">
+                                    <tgroup cols="2">
+                                        <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+                                        <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+                                        <tbody>
+                                            <row>
+                                                <entry>Debian / Ubuntu package</entry>
+                                                <entry><package>libtool-bin</package></entry>
+                                            </row>
+                                            <row>
+                                                <entry>Fedora / CentOS / RHEL package</entry>
+                                                <entry><package>libtool</package></entry>
+                                            </row>
+                                        </tbody>
+                                    </tgroup>
+                                </informaltable>
+                            </entry>
+                        </row>
+                        <row>
                             <entry><link xl:href="http://www.ossp.org/pkg/lib/uuid/">OSSP
                                     UUID</link></entry>
                             <entry>


### PR DESCRIPTION
Fixes GUACAMOLE-639: Add installation of libtool-bin for Debian/Ubuntu

When building Apache Guacamole from source, libtool-bin is required on
Debian/Ubuntu systems. 

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>