### PR TITLE
GUACAMOLE-524: Document new format of custom LDAP parameter tokens.

### DIFF
--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -4308,21 +4308,6 @@ guaclog: INFO: All files interpreted successfully.</computeroutput>
                             time that the connection began.</para>
                     </listitem>
                 </varlistentry>
-                <varlistentry>
-                    <term><varname>${GUAC_ATTR_<replaceable>CUSTOM_ATTRIBUTE_NAME</replaceable>}</varname></term>
-                    <listitem>
-                        <para>An attribute value specified on the current Guacamole user.
-                            <replaceable>CUSTOM_ATTRIBUTE_NAME</replaceable> is a custom
-                            user attribute that may be obtained from any of the authentication
-                            modules that implement the feature. There are an arbitrary
-                            number of these tokens. If no attributes are specified
-                            then this token does not exist.</para>
-                        <para>For example, if an attribute name is specified as "mail" then a token would
-                            be set as <varname>${GUAC_ATTR_MAIL}</varname> with the value of "mail" in the authentication
-                            module that "mail" is specified in. For a practical example, see
-                            <property>ldap-user-attributes</property> in <xref linkend="ldap-auth"/>.</para>
-                    </listitem>
-                </varlistentry>
             </variablelist>
             <para>Note that these tokens are replaced dynamically each time a connection is used. If
                 two different users access the same connection at the same time, both users will be

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -359,27 +359,62 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
                 <varlistentry>
                     <term><property>ldap-user-attributes</property></term>
                     <listitem>
-                        <para>The attribute or attributes to retrieve from the LDAP directory
-                            for the currently logged-in user. These attributes are stored as
-                            tokens with the prefix "GUAC_ATTR_" and the name of the attribute appended
-                            in uppercase letters. The value of the token is the value of the attribute
-                            in the LDAP directory for the currently logged-in user. If the attribute
-                            has no value in the LDAP directory then the token is not saved.
-                            If the attribute has multiple values in the LDAP directory then the token
-                            saves the first value of the attribute. Multiple attributes can be
-                            specified here, separated by commas.</para>
-                        <para>For example, if <property>ldap-user-attributes</property> is
-                            "<systemitem>mail, workstation</systemitem>", then a GUAC_ATTR_MAIL
-                            token would be set to the value of the mail attribute in the LDAP directory
-                            for the currently logged-in user and a GUAC_ATTR_WORKSTATION token
-                            would be set to the value of the workstation attribute similarly,
-                            contingent on the fact that the attributes have a value in the LDAP directory.
-                            So, the tokens could be used like this:
-                            <varname>${GUAC_ATTR_MAIL}</varname> or <varname>${GUAC_ATTR_WORKSTATION}</varname>.
-                            If the value of mail in the LDAP directory is "example@email.com" then
-                            <varname>${GUAC_ATTR_MAIL}</varname> would have the value "example@email.com".
-                            Tokens usage is discussed more in <xref linkend="configuring-guacamole"/> in
-                            <xref linkend="parameter-tokens"/>.</para>
+                        <para>The attribute or attributes to retrieve from the LDAP directory for
+                            the currently logged-in user, separated by commas. If specified, the
+                            attributes listed here are retrieved from each authenticated user and
+                            dynamically applied to the parameters of that user's connections as
+                                <link linkend="parameter-tokens">parameter tokens</link> with the
+                            prefix "<varname>LDAP_</varname>".</para>
+                        <para>When a user authenticates with LDAP and accesses a particular
+                            Guacamole connection, the values of these tokens will be the values of
+                            their corresponding attributes at the time of authentication. If the
+                            attribute has no value for the current user, then the corresponding
+                            token is not applied. If the attribute has multiple values, then the
+                            first value of the attribute is used.</para>
+                        <para>When converting an LDAP attribute name into a parameter token name,
+                            the name of the attribute is transformed into uppercase with each word
+                            separated by underscores, a naming convention referred to as "uppercase
+                            with underscores" or "<link
+                                xlink:href="https://en.wikipedia.org/wiki/Naming_convention_(programming)#Multiple-word_identifiers"
+                                >screaming snake case</link>". For example:</para>
+                        <table frame="all">
+                            <title>Example LDAP attribute / parameter token conversions</title>
+                            <tgroup cols="2">
+                                <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+                                <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+                                <thead>
+                                    <row>
+                                        <entry>LDAP Attribute</entry>
+                                        <entry>Parameter Token</entry>
+                                    </row>
+                                </thead>
+                                <tbody>
+                                    <row>
+                                        <entry><varname>lowercase-with-dashes</varname></entry>
+                                        <entry><varname>${LDAP_LOWERCASE_WITH_DASHES}</varname></entry>
+                                    </row>
+                                    <row>
+                                        <entry><varname>CamelCase</varname></entry>
+                                        <entry><varname>${LDAP_CAMEL_CASE}</varname></entry>
+                                    </row>
+                                    <row>
+                                        <entry><varname>headlessCamelCase</varname></entry>
+                                        <entry><varname>${LDAP_HEADLESS_CAMEL_CASE}</varname></entry>
+                                    </row>
+                                    <row>
+                                        <entry><varname>lettersAndNumbers1234</varname></entry>
+                                        <entry><varname>${LDAP_LETTERS_AND_NUMBERS_1234}</varname></entry>
+                                    </row>
+                                    <row>
+                                        <entry><varname>aRANDOM_mixOf-3NAMINGConventions</varname></entry>
+                                        <entry><varname>${LDAP_A_RANDOM_MIX_OF_3_NAMING_CONVENTIONS}</varname></entry>
+                                    </row>
+                                </tbody>
+                            </tgroup>
+                        </table>
+                        <para>Usage of parameter tokens is discussed in more detail in <xref
+                                linkend="configuring-guacamole"/> in <xref
+                                linkend="parameter-tokens"/>.</para>
                     </listitem>
                 </varlistentry>
                 <varlistentry>


### PR DESCRIPTION
This change updates the LDAP attribute parameter token documentation to note the new `LDAP_` prefix and removes the documentation which covered the generic `GUAC_ATTR_` tokens (which no longer exist).