### PR TITLE
GUACAMOLE-570: Bump version numbers within documentation to 1.0.0.

### DIFF
--- a/src/chapters/adhoc-connections.xml
+++ b/src/chapters/adhoc-connections.xml
@@ -43,7 +43,7 @@
                 xlink:href="http://guacamole.apache.org/releases/"
                 >http://guacamole.apache.org/releases/</link>.</para>
         <para>The quickconnect extension is packaged as a <filename>.tar.gz</filename> file containing
-            only the extension itself, <filename>guacamole-auth-quickconnect-0.9.14.jar</filename>, which must
+            only the extension itself, <filename>guacamole-auth-quickconnect-1.0.0.jar</filename>, which must
             ultimately be placed in <filename>GUACAMOLE_HOME/extensions</filename>.</para>
     </section>
     <section xml:id="installing-quickconnect">
@@ -60,7 +60,7 @@
                     does not already exist.</para>
             </step>
             <step>
-                <para>Place the <filename>guacamole-auth-quickconnect-0.9.14.jar</filename> file in
+                <para>Place the <filename>guacamole-auth-quickconnect-1.0.0.jar</filename> file in
                     the <filename>GUACAMOLE_HOME/extensions</filename> directory.</para>
             </step>
         </procedure>

--- a/src/chapters/cas-auth.xml
+++ b/src/chapters/cas-auth.xml
@@ -23,7 +23,7 @@
                 >http://guacamole.apache.org/releases/</link>.</para>
         <para>The CAS authentication extension is packaged as a <filename>.tar.gz</filename>
             file containing only the extension itself,
-                <filename>guacamole-auth-cas-0.9.14.jar</filename>, which must
+                <filename>guacamole-auth-cas-1.0.0.jar</filename>, which must
             ultimately be placed in <filename>GUACAMOLE_HOME/extensions</filename>.</para>
     </section>
     <section xml:id="installing-cas-auth">
@@ -40,7 +40,7 @@
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-cas-0.9.14.jar</filename> within
+                <para>Copy <filename>guacamole-auth-cas-1.0.0.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -685,7 +685,7 @@ guacd-port:     4822</programlisting>
                     events:</para>
                 <informalexample>
                     <screen><prompt>$</prompt> <userinput>guaclog <replaceable>/path/to/recording/NAME</replaceable></userinput><computeroutput>
-guaclog: INFO: Guacamole input log interpreter (guaclog) version 0.9.14
+guaclog: INFO: Guacamole input log interpreter (guaclog) version 1.0.0
 guaclog: INFO: 1 input file(s) provided.
 guaclog: INFO: Writing input events from "<replaceable>/path/to/recording/NAME</replaceable>" to "<replaceable annotations="">/path/to/recording/NAME</replaceable>.txt" ...
 guaclog: INFO: All files interpreted successfully.</computeroutput>
@@ -1865,7 +1865,7 @@ tcp6       0      0 :::4713                 :::*                    LISTEN</comp
                     events:</para>
                 <informalexample>
                     <screen><prompt>$</prompt> <userinput>guaclog <replaceable>/path/to/recording/NAME</replaceable></userinput><computeroutput>
-guaclog: INFO: Guacamole input log interpreter (guaclog) version 0.9.14
+guaclog: INFO: Guacamole input log interpreter (guaclog) version 1.0.0
 guaclog: INFO: 1 input file(s) provided.
 guaclog: INFO: Writing input events from "<replaceable>/path/to/recording/NAME</replaceable>" to "<replaceable annotations="">/path/to/recording/NAME</replaceable>.txt" ...
 guaclog: INFO: All files interpreted successfully.</computeroutput>
@@ -3378,7 +3378,7 @@ color9: rgb:80/00/80</programlisting>
                     events:</para>
                 <informalexample>
                     <screen><prompt>$</prompt> <userinput>guaclog <replaceable>/path/to/recording/NAME</replaceable></userinput><computeroutput>
-guaclog: INFO: Guacamole input log interpreter (guaclog) version 0.9.14
+guaclog: INFO: Guacamole input log interpreter (guaclog) version 1.0.0
 guaclog: INFO: 1 input file(s) provided.
 guaclog: INFO: Writing input events from "<replaceable>/path/to/recording/NAME</replaceable>" to "<replaceable annotations="">/path/to/recording/NAME</replaceable>.txt" ...
 guaclog: INFO: All files interpreted successfully.</computeroutput>
@@ -4084,7 +4084,7 @@ color9: rgb:80/00/80</programlisting>
                     events:</para>
                 <informalexample>
                     <screen><prompt>$</prompt> <userinput>guaclog <replaceable>/path/to/recording/NAME</replaceable></userinput><computeroutput>
-guaclog: INFO: Guacamole input log interpreter (guaclog) version 0.9.14
+guaclog: INFO: Guacamole input log interpreter (guaclog) version 1.0.0
 guaclog: INFO: 1 input file(s) provided.
 guaclog: INFO: Writing input events from "<replaceable>/path/to/recording/NAME</replaceable>" to "<replaceable annotations="">/path/to/recording/NAME</replaceable>.txt" ...
 guaclog: INFO: All files interpreted successfully.</computeroutput>

--- a/src/chapters/custom-auth.xml
+++ b/src/chapters/custom-auth.xml
@@ -58,7 +58,7 @@
     &lt;groupId>org.apache.guacamole&lt;/groupId>
     &lt;artifactId>guacamole-auth-tutorial&lt;/artifactId>
     &lt;packaging>jar&lt;/packaging>
-    &lt;version>0.9.14&lt;/version>
+    &lt;version>1.0.0&lt;/version>
     &lt;name>guacamole-auth-tutorial&lt;/name>
 
     &lt;properties>
@@ -88,7 +88,7 @@
         &lt;dependency>
             &lt;groupId>org.apache.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-ext&lt;/artifactId>
-            &lt;version>0.9.14&lt;/version>
+            &lt;version>1.0.0&lt;/version>
             &lt;scope>provided&lt;/scope>
         &lt;/dependency>
 
@@ -172,7 +172,7 @@ public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider
             <title>The required <filename>guac-manifest.json</filename></title>
             <programlisting>{
 
-    "guacamoleVersion" : "0.9.14",
+    "guacamoleVersion" : "1.0.0",
 
     "name"      : "Tutorial Authentication Extension",
     "namespace" : "guac-auth-tutorial",
@@ -196,7 +196,7 @@ public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider
             <screen><prompt>$</prompt> mvn package
 <computeroutput>[INFO] Scanning for projects...
 [INFO] ------------------------------------------------------------------------
-[INFO] Building guacamole-auth-tutorial 0.9.14
+[INFO] Building guacamole-auth-tutorial 1.0.0
 [INFO] ------------------------------------------------------------------------
 ...
 [INFO] ------------------------------------------------------------------------
@@ -210,7 +210,7 @@ public class TutorialAuthenticationProvider extends SimpleAuthenticationProvider
         </informalexample>
         <para>Assuming you see the "<computeroutput>BUILD SUCCESS</computeroutput>" message when you
             build the extension, there will be a new file,
-                <filename>target/guacamole-auth-tutorial-0.9.14.jar</filename>, which can be
+                <filename>target/guacamole-auth-tutorial-1.0.0.jar</filename>, which can be
             installed within Guacamole and tested. If you changed the name or version of the project
             in the <filename>pom.xml</filename> file, the name of this new <filename>.jar</filename>
             file will be different, but it can still be found within
@@ -472,7 +472,7 @@ public Map&lt;String, GuacamoleConfiguration>
             user running Tomcat.</para>
         <para>To install your extension, ensure that the required properties have been added to your
                 <filename>guacamole.properties</filename>, copy the
-                <filename>target/guacamole-auth-tutorial-0.9.14.jar</filename> file into
+                <filename>target/guacamole-auth-tutorial-1.0.0.jar</filename> file into
                 <filename>GUACAMOLE_HOME/extensions</filename> and restart Tomcat. Guacamole will
             automatically load your extension, logging an informative message that it has done
             so:</para>

--- a/src/chapters/duo-auth.xml
+++ b/src/chapters/duo-auth.xml
@@ -55,7 +55,7 @@
                 >http://guacamole.apache.org/releases/</link>.</para>
         <para>The Duo authentication extension is packaged as a <filename>.tar.gz</filename> file
             containing only the extension itself,
-                <filename>guacamole-auth-duo-0.9.14.jar</filename>, which must ultimately
+                <filename>guacamole-auth-duo-1.0.0.jar</filename>, which must ultimately
             be placed in <filename>GUACAMOLE_HOME/extensions</filename>.</para>
     </section>
     <section xml:id="installing-duo-auth">
@@ -69,7 +69,7 @@
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-duo-0.9.14.jar</filename> within
+                <para>Copy <filename>guacamole-auth-duo-1.0.0.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/event-listeners.xml
+++ b/src/chapters/event-listeners.xml
@@ -52,7 +52,7 @@
     &lt;groupId>org.apache.guacamole&lt;/groupId>
     &lt;artifactId>guacamole-listener-tutorial&lt;/artifactId>
     &lt;packaging>jar&lt;/packaging>
-    &lt;version>0.9.14&lt;/version>
+    &lt;version>1.0.0&lt;/version>
     &lt;name>guacamole-listener-tutorial&lt;/name>
 
     &lt;properties>
@@ -82,7 +82,7 @@
         &lt;dependency>
             &lt;groupId>org.apache.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-ext&lt;/artifactId>
-            &lt;version>0.9.14&lt;/version>
+            &lt;version>1.0.0&lt;/version>
             &lt;scope>provided&lt;/scope>
         &lt;/dependency>
 
@@ -159,7 +159,7 @@ public class TutorialListener implements Listener {
             <title>The required <filename>guac-manifest.json</filename></title>
             <programlisting>{
 
-    "guacamoleVersion" : "0.9.14",
+    "guacamoleVersion" : "1.0.0",
 
     "name"      : "Tutorial Listener Extension",
     "namespace" : "guac-listener-tutorial",
@@ -179,7 +179,7 @@ public class TutorialListener implements Listener {
             <screen><prompt>$</prompt> mvn package
 <computeroutput>[INFO] Scanning for projects...
 [INFO] ---------------------------------------------------------------
-[INFO] Building guacamole-listener-tutorial 0.9.14
+[INFO] Building guacamole-listener-tutorial 1.0.0
 [INFO] ---------------------------------------------------------------
 ...
 [INFO] ---------------------------------------------------------------
@@ -193,7 +193,7 @@ public class TutorialListener implements Listener {
         </informalexample>
         <para>Assuming you see the "<computeroutput>BUILD SUCCESS</computeroutput>" message when you
             build the extension, there will be a new file,
-                <filename>target/guacamole-listener-tutorial-0.9.14.jar</filename>, which can be
+                <filename>target/guacamole-listener-tutorial-1.0.0.jar</filename>, which can be
             installed within Guacamole (see <xref xmlns:xlink="http://www.w3.org/1999/xlink"
                 linkend="custom-listener-installing"/> at the end of this chapter). It should log
             event notifications that occur during, for example, authentication attempts.
@@ -341,7 +341,7 @@ public class TutorialListener implements Listener {
             will be the <filename>.guacamole</filename> directory within the home directory of the
             user running Tomcat.</para>
         <para>To install your extension, copy the
-            <filename>target/guacamole-listener-tutorial-0.9.14.jar</filename> file into
+            <filename>target/guacamole-listener-tutorial-1.0.0.jar</filename> file into
             <filename>GUACAMOLE_HOME/extensions</filename> and restart Tomcat. Guacamole will
             automatically load your extension, logging an informative message that it has done
             so:</para>

--- a/src/chapters/guacamole-ext.xml
+++ b/src/chapters/guacamole-ext.xml
@@ -186,7 +186,7 @@
                     <filename>guac-manifest.json</filename> will look something like this:</para>
             <informalexample>
                 <programlisting>{
-    "guacamoleVersion" : "0.9.14",
+    "guacamoleVersion" : "1.0.0",
     "name" : "My Extension",
     "namespace" : "my-extension"
 }</programlisting>
@@ -198,7 +198,7 @@
             <informalexample>
                 <programlisting>{
 
-    "guacamoleVersion" : "0.9.14",
+    "guacamoleVersion" : "1.0.0",
 
     "name"      : "My Extension",
     "namespace" : "my-extension",

--- a/src/chapters/header-auth.xml
+++ b/src/chapters/header-auth.xml
@@ -29,7 +29,7 @@
                 >http://guacamole.apache.org/releases/</link>.</para>
         <para>The HTTP header authentication extension is packaged as a <filename>.tar.gz</filename>
             file containing only the extension itself,
-                <filename>guacamole-auth-header-0.9.14.jar</filename>, which must
+                <filename>guacamole-auth-header-1.0.0.jar</filename>, which must
             ultimately be placed in <filename>GUACAMOLE_HOME/extensions</filename>.</para>
     </section>
     <section xml:id="installing-header-auth">
@@ -46,7 +46,7 @@
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-header-0.9.14.jar</filename> within
+                <para>Copy <filename>guacamole-auth-header-1.0.0.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/installing.xml
+++ b/src/chapters/installing.xml
@@ -555,8 +555,8 @@
                 of a <filename>.tar.gz</filename> archive which you can extract from the command
                 line:</para>
             <informalexample>
-                <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-server-0.9.14.tar.gz</userinput>
-<prompt>$</prompt> <userinput>cd guacamole-server-0.9.14/</userinput>
+                <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-server-1.0.0.tar.gz</userinput>
+<prompt>$</prompt> <userinput>cd guacamole-server-1.0.0/</userinput>
 <prompt>$</prompt></screen>
             </informalexample>
             <para>If you want the absolute latest code, and don't care that the code hasn't been as
@@ -608,7 +608,7 @@ checking whether build environment is sane... yes
 ...
 
 ------------------------------------------------
-guacamole-server version 0.9.14
+guacamole-server version 1.0.0
 ------------------------------------------------
 
    Library status:
@@ -785,8 +785,8 @@ make[1]: Leaving directory `/home/zhz/guacamole/guacamole-server'</computeroutpu
                 <filename>.tar.gz</filename> archive which you can extract from the command
             line:</para>
         <informalexample>
-            <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-client-0.9.14.tar.gz</userinput>
-<prompt>$</prompt> <userinput>cd guacamole-client-0.9.14/</userinput>
+            <screen><prompt>$</prompt> <userinput>tar -xzf guacamole-client-1.0.0.tar.gz</userinput>
+<prompt>$</prompt> <userinput>cd guacamole-client-1.0.0/</userinput>
 <prompt>$</prompt></screen>
         </informalexample>
         <para>As with <package>guacamole-server</package>, if you want the absolute latest code, and
@@ -880,7 +880,7 @@ Resolving deltas: 100% (3942/3942), done.</computeroutput>
             application from the name of the <filename>.war</filename> file, you will likely want to
             rename this to simply <filename>guacamole.war</filename> while copying:</para>
         <informalexample>
-            <screen><prompt>#</prompt> <userinput>cp guacamole/target/guacamole-0.9.14.war <replaceable>/var/lib/tomcat/webapps</replaceable>/guacamole.war</userinput>
+            <screen><prompt>#</prompt> <userinput>cp guacamole/target/guacamole-1.0.0.war <replaceable>/var/lib/tomcat/webapps</replaceable>/guacamole.war</userinput>
 <prompt>#</prompt></screen>
         </informalexample>
         <para>Again, if you are using a different servlet container or if Tomcat is installed to a
@@ -898,7 +898,7 @@ Resolving deltas: 100% (3942/3942), done.</computeroutput>
 Starting Tomcat... OK</computeroutput>
 <prompt>#</prompt> <userinput>/etc/init.d/guacd start</userinput>
 <computeroutput>Starting guacd: SUCCESS
-guacd[6229]: INFO:  Guacamole proxy daemon (guacd) version 0.9.14 started</computeroutput>
+guacd[6229]: INFO:  Guacamole proxy daemon (guacd) version 1.0.0 started</computeroutput>
 <prompt>#</prompt></screen>
         </informalexample>
         <important>

--- a/src/chapters/installing.xml
+++ b/src/chapters/installing.xml
@@ -625,6 +625,7 @@ guacamole-server version 1.0.0
      libvorbis ........... yes
      libpulse ............ yes
      libwebp ............. yes
+     wsock32 ............. no
 
    Protocol support:
 
@@ -640,6 +641,7 @@ guacamole-server version 1.0.0
       guaclog .... yes
 
    Init scripts: /etc/init.d
+   Systemd units: no
 
 Type "make" to compile guacamole-server.
 </computeroutput>
@@ -820,34 +822,52 @@ Resolving deltas: 100% (3942/3942), done.</computeroutput>
 [INFO] guacamole-ext
 [INFO] guacamole-common-js
 [INFO] guacamole
+[INFO] guacamole-auth-cas
+[INFO] guacamole-auth-duo
+[INFO] guacamole-auth-header
 [INFO] guacamole-auth-jdbc
 [INFO] guacamole-auth-jdbc-base
 [INFO] guacamole-auth-jdbc-mysql
 [INFO] guacamole-auth-jdbc-postgresql
+[INFO] guacamole-auth-jdbc-sqlserver
+[INFO] guacamole-auth-jdbc-dist
 [INFO] guacamole-auth-ldap
-[INFO] guacamole-auth-noauth
+[INFO] guacamole-auth-openid
+[INFO] guacamole-auth-quickconnect
+[INFO] guacamole-auth-totp
+[INFO] guacamole-example
+[INFO] guacamole-playback-example
 [INFO] guacamole-client
 ...
 [INFO] ------------------------------------------------------------------------
 [INFO] Reactor Summary:
 [INFO] 
-[INFO] guacamole-common ................................... SUCCESS [  7.566 s]
-[INFO] guacamole-ext ...................................... SUCCESS [  5.594 s]
-[INFO] guacamole-common-js ................................ SUCCESS [  1.249 s]
-[INFO] guacamole .......................................... SUCCESS [  8.474 s]
-[INFO] guacamole-auth-jdbc ................................ SUCCESS [  0.592 s]
-[INFO] guacamole-auth-jdbc-base ........................... SUCCESS [  2.548 s]
-[INFO] guacamole-auth-jdbc-mysql .......................... SUCCESS [  2.557 s]
-[INFO] guacamole-auth-jdbc-postgresql ..................... SUCCESS [  1.990 s]
-[INFO] guacamole-auth-ldap ................................ SUCCESS [  1.314 s]
-[INFO] guacamole-auth-noauth .............................. SUCCESS [  0.961 s]
-[INFO] guacamole-client ................................... SUCCESS [  1.721 s]
+[INFO] guacamole-common ................................... SUCCESS [ 21.852 s]
+[INFO] guacamole-ext ...................................... SUCCESS [  9.055 s]
+[INFO] guacamole-common-js ................................ SUCCESS [  1.988 s]
+[INFO] guacamole .......................................... SUCCESS [ 18.040 s]
+[INFO] guacamole-auth-cas ................................. SUCCESS [  4.203 s]
+[INFO] guacamole-auth-duo ................................. SUCCESS [  2.251 s]
+[INFO] guacamole-auth-header .............................. SUCCESS [  1.399 s]
+[INFO] guacamole-auth-jdbc ................................ SUCCESS [  1.396 s]
+[INFO] guacamole-auth-jdbc-base ........................... SUCCESS [  3.266 s]
+[INFO] guacamole-auth-jdbc-mysql .......................... SUCCESS [  4.665 s]
+[INFO] guacamole-auth-jdbc-postgresql ..................... SUCCESS [  3.764 s]
+[INFO] guacamole-auth-jdbc-sqlserver ...................... SUCCESS [  3.738 s]
+[INFO] guacamole-auth-jdbc-dist ........................... SUCCESS [  1.214 s]
+[INFO] guacamole-auth-ldap ................................ SUCCESS [  1.991 s]
+[INFO] guacamole-auth-openid .............................. SUCCESS [  2.204 s]
+[INFO] guacamole-auth-quickconnect ........................ SUCCESS [  2.983 s]
+[INFO] guacamole-auth-totp ................................ SUCCESS [  8.154 s]
+[INFO] guacamole-example .................................. SUCCESS [  0.895 s]
+[INFO] guacamole-playback-example ......................... SUCCESS [  0.795 s]
+[INFO] guacamole-client ................................... SUCCESS [  7.478 s]
 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD SUCCESS
 [INFO] ------------------------------------------------------------------------
-[INFO] Total time: 34.701 s
-[INFO] Finished at: 2015-06-08T17:03:15-07:00
-[INFO] Final Memory: 34M/340M
+[INFO] Total time: 01:41 min
+[INFO] Finished at: 2018-10-15T17:08:29-07:00
+[INFO] Final Memory: 42M/379M
 [INFO] ------------------------------------------------------------------------</computeroutput>
 <prompt>$</prompt></screen>
         </informalexample>

--- a/src/chapters/jdbc-auth.xml
+++ b/src/chapters/jdbc-auth.xml
@@ -61,11 +61,11 @@
                 <term><filename>mysql/</filename></term>
                 <listitem>
                     <para>Contains the MySQL/MariaDB authentication extension,
-                            <filename>guacamole-auth-jdbc-mysql-0.9.14.jar</filename>,
-                        along with a <filename>schema/</filename> directory containing
-                        MySQL-specific SQL scripts required to set up the database. The
-                            <filename>guacamole-auth-jdbc-mysql-0.9.14.jar</filename>
-                        file will ultimately need to be placed within
+                            <filename>guacamole-auth-jdbc-mysql-1.0.0.jar</filename>, along with a
+                            <filename>schema/</filename> directory containing MySQL-specific SQL
+                        scripts required to set up the database. The
+                            <filename>guacamole-auth-jdbc-mysql-1.0.0.jar</filename> file will
+                        ultimately need to be placed within
                             <filename>GUACAMOLE_HOME/extensions</filename>, while the MySQL JDBC
                         driver must be placed within <filename>GUACAMOLE_HOME/lib</filename>.</para>
                     <para><emphasis>The MySQL JDBC driver is not included with the
@@ -81,11 +81,11 @@
                 <term><filename>postgresql/</filename></term>
                 <listitem>
                     <para>Contains the PostgreSQL authentication extension,
-                            <filename>guacamole-auth-jdbc-postgresql-0.9.14.jar</filename>,
-                        along with a <filename>schema/</filename> directory containing
-                        PostgreSQL-specific SQL scripts required to set up the database. The
-                            <filename>guacamole-auth-jdbc-postgresql-0.9.14.jar</filename>
-                        file will ultimately need to be placed within
+                            <filename>guacamole-auth-jdbc-postgresql-1.0.0.jar</filename>, along
+                        with a <filename>schema/</filename> directory containing PostgreSQL-specific
+                        SQL scripts required to set up the database. The
+                            <filename>guacamole-auth-jdbc-postgresql-1.0.0.jar</filename> file will
+                        ultimately need to be placed within
                             <filename>GUACAMOLE_HOME/extensions</filename>, while the PostgreSQL
                         JDBC driver must be placed within
                         <filename>GUACAMOLE_HOME/lib</filename>.</para>
@@ -101,12 +101,12 @@
                 <term><filename>sqlserver/</filename></term>
                 <listitem>
                     <para>Contains the SQL Server authentication extension,
-                        <filename>guacamole-auth-jdbc-sqlserver-0.9.14.jar</filename>,
-                        along with a <filename>schema/</filename> directory contains SQL Server-specific
-                        scripts requires to set up the database.  The JAR extension file will need to be
-                        placed within the <filename>GUACAMOLE_HOME/extensions</filename> folder, while the
-                        SQL Server JDBC driver must be placed within the <filename>GUACAMOLE_HOME/lib</filename>
-                        directory.</para>
+                            <filename>guacamole-auth-jdbc-sqlserver-1.0.0.jar</filename>, along with
+                        a <filename>schema/</filename> directory contains SQL Server-specific
+                        scripts requires to set up the database. The JAR extension file will need to
+                        be placed within the <filename>GUACAMOLE_HOME/extensions</filename> folder,
+                        while the SQL Server JDBC driver must be placed within the
+                            <filename>GUACAMOLE_HOME/lib</filename> directory.</para>
                     <para><emphasis>The SQL Server JDBC driver is not included with the extension.</emphasis>  You
                         must obtain the JDBC driver <filename>.jar</filename> yourself and place it in the directory.
                         Furthermore, the SQL Server authentication extension supports a number of TDS-compatible
@@ -396,11 +396,11 @@ The new rule has been bound to column(s) of the specified user data type.</compu
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-jdbc-mysql-0.9.14.jar</filename>
+                <para>Copy <filename>guacamole-auth-jdbc-mysql-1.0.0.jar</filename>
                     <emphasis>or</emphasis>
-                    <filename>guacamole-auth-jdbc-postgresql-0.9.14.jar</filename>
+                    <filename>guacamole-auth-jdbc-postgresql-1.0.0.jar</filename>
                     <emphasis>or</emphasis>
-                    <filename>guacamole-auth-jdbc-sqlserver-0.9.14.jar</filename> within
+                    <filename>guacamole-auth-jdbc-sqlserver-1.0.0.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>, depending on whether you are
                     using MySQL/MariaDB, PostgreSQL, or SQL Server.</para>
             </step>

--- a/src/chapters/ldap-auth.xml
+++ b/src/chapters/ldap-auth.xml
@@ -83,7 +83,7 @@
             containing:</para>
         <variablelist>
             <varlistentry>
-                <term><filename>guacamole-auth-ldap-0.9.14.jar</filename></term>
+                <term><filename>guacamole-auth-ldap-1.0.0.jar</filename></term>
                 <listitem>
                     <para>The Guacamole LDAP support extension itself, which must be placed in
                             <filename>GUACAMOLE_HOME/extensions</filename>.</para>
@@ -211,7 +211,7 @@ dn: cn={4}guacConfigGroup,cn=schema,cn=config
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-ldap-0.9.14.jar</filename> within
+                <para>Copy <filename>guacamole-auth-ldap-1.0.0.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/openid-auth.xml
+++ b/src/chapters/openid-auth.xml
@@ -31,7 +31,7 @@
                 >http://guacamole.apache.org/releases/</link>.</para>
         <para>The OpenID Connect authentication extension is packaged as a
                 <filename>.tar.gz</filename> file containing only the extension itself,
-                <filename>guacamole-auth-openid-0.9.14.jar</filename>, which must ultimately be
+                <filename>guacamole-auth-openid-1.0.0.jar</filename>, which must ultimately be
             placed in <filename>GUACAMOLE_HOME/extensions</filename>.</para>
     </section>
     <section xml:id="installing-openid-auth">
@@ -48,7 +48,7 @@
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-openid-0.9.14.jar</filename> within
+                <para>Copy <filename>guacamole-auth-openid-1.0.0.jar</filename> within
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/radius-auth.xml
+++ b/src/chapters/radius-auth.xml
@@ -29,7 +29,7 @@
             <screen><prompt>$</prompt> <userinput>mvn clean package -Plgpl-extensions</userinput>
 <computeroutput>[INFO] --- maven-assembly-plugin:2.5.3:single (make-source-archive) @ guacamole-client ---
 [INFO] Reading assembly descriptor: project-assembly.xml
-[INFO] Building tar: /home/guac/guacamole-client/target/guacamole-client-0.9.14.tar.gz
+[INFO] Building tar: /home/guac/guacamole-client/target/guacamole-client-1.0.0.tar.gz
 [INFO] ------------------------------------------------------------------------
 [INFO] Reactor Summary:
 [INFO] 
@@ -65,7 +65,7 @@
 
         <para>After the build completes successfully, the extension will be in the
             <filename>extensions/guacamole-auth-radius/target/</filename> directory, and will be
-            called guacamole-auth-radius-0.9.14.jar.  This extension file can be copied to
+            called guacamole-auth-radius-1.0.0.jar.  This extension file can be copied to
             the <filename>GUACAMOLE_HOME/extensions</filename> directory.
             <emphasis>If you are unsure where <varname>GUACAMOLE_HOME</varname> is located on
             your system, please consult <xref linkend="configuring-guacamole"/> before
@@ -86,7 +86,7 @@
                     does not already exist.</para>
             </step>
             <step>
-                <para>Copy <filename>guacamole-auth-radius-0.9.14.jar</filename> into
+                <para>Copy <filename>guacamole-auth-radius-1.0.0.jar</filename> into
                         <filename>GUACAMOLE_HOME/extensions</filename>.</para>
             </step>
             <step>

--- a/src/chapters/yourown.xml
+++ b/src/chapters/yourown.xml
@@ -112,7 +112,7 @@
     &lt;groupId>org.apache.guacamole&lt;/groupId>
     &lt;artifactId>guacamole-tutorial&lt;/artifactId>
     &lt;packaging>war&lt;/packaging>
-    &lt;version>0.9.14&lt;/version>
+    &lt;version>1.0.0&lt;/version>
     &lt;name>guacamole-tutorial&lt;/name>
 
     &lt;properties>
@@ -201,7 +201,7 @@
             </informalexample>
             <para>Assuming you see the "<computeroutput>BUILD SUCCESSFUL</computeroutput>" message
                 when you build the web application, there will be a new file,
-                    <filename>target/guacamole-tutorial-0.9.14.war</filename>, which
+                    <filename>target/guacamole-tutorial-1.0.0.war</filename>, which
                 can be deployed to your servlet container and tested. If you changed the name or
                 version of the project in the <filename>pom.xml</filename> file, the name of this new
                     <filename>.war</filename> file will be different, but it can still be found
@@ -304,7 +304,7 @@
         &lt;dependency>
             &lt;groupId>org.apache.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-common&lt;/artifactId>
-            &lt;version>0.9.14&lt;/version>
+            &lt;version>1.0.0&lt;/version>
             &lt;scope>compile&lt;/scope>
         &lt;/dependency>
 
@@ -312,7 +312,7 @@
         &lt;dependency>
             &lt;groupId>org.apache.guacamole&lt;/groupId>
             &lt;artifactId>guacamole-common-js&lt;/artifactId>
-            &lt;version>0.9.14&lt;/version>
+            &lt;version>1.0.0&lt;/version>
             &lt;type>zip&lt;/type>
             &lt;scope>runtime&lt;/scope>
         &lt;/dependency>
@@ -331,7 +331,7 @@
                 web application should build successfully, and the Guacamole JavaScript API should
                 be accessible in the <filename>guacamole-common-js/</filename> subdirectory of your
                 web application after it is deployed. A quick check that you can access
-                    <uri>/guacamole-tutorial-0.9.14/guacamole-common-js/all.min.js</uri>
+                    <uri>/guacamole-tutorial-1.0.0/guacamole-common-js/all.min.js</uri>
                 is probably worth the effort.</para>
         </section>
         <section xml:id="simple-tunnel">
@@ -430,7 +430,7 @@ public class TutorialGuacamoleTunnelServlet
                 to the URL we wish to use when making HTTP requests to the servlet:
                     <uri>/tunnel</uri>. This URL is relative to the context root of the web
                 application. In the case of this web application, the final absolute URL will be
-                    <uri>/guacamole-tutorial-0.9.14/tunnel</uri>.</para>
+                    <uri>/guacamole-tutorial-1.0.0/tunnel</uri>.</para>
         </section>
         <section xml:id="simple-client">
             <title>Adding the client</title>

--- a/src/gug.xml
+++ b/src/gug.xml
@@ -3,7 +3,7 @@
     xmlns:xi="http://www.w3.org/2001/XInclude">
     <info>
         <title>Guacamole Manual</title>
-        <edition>0.9.14</edition>
+        <edition>1.0.0</edition>
         <legalnotice>
             <para>Licensed to the Apache Software Foundation (ASF) under one or more contributor
                 license agreements. See the <link xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -42,7 +42,7 @@
             application, etc.) to give a good starting point beyond simply looking at the Guacamole
             codebase.</para>
         <para>This particular edition of the <citetitle>Guacamole Manual</citetitle> covers
-            Guacamole version 0.9.14. New releases which create new features or break
+            Guacamole version 1.0.0. New releases which create new features or break
             compatibility will result in new editions of the user's guide, as will any necessary
             corrections. As the official documentation for the project, this book will always be
             freely available in its entirety online.</para>

--- a/tutorials/guacamole-auth-tutorial/pom.xml
+++ b/tutorials/guacamole-auth-tutorial/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-tutorial</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.14</version>
+    <version>1.0.0</version>
     <name>guacamole-auth-tutorial</name>
 
     <properties>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.14</version>
+            <version>1.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/tutorials/guacamole-auth-tutorial/src/main/resources/guac-manifest.json
+++ b/tutorials/guacamole-auth-tutorial/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "0.9.14",
+    "guacamoleVersion" : "1.0.0",
 
     "name"      : "Tutorial Authentication Extension",
     "namespace" : "guac-auth-tutorial",

--- a/tutorials/guacamole-tutorial/pom.xml
+++ b/tutorials/guacamole-tutorial/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-tutorial</artifactId>
     <packaging>war</packaging>
-    <version>0.9.14</version>
+    <version>1.0.0</version>
     <name>guacamole-tutorial</name>
 
     <properties>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common</artifactId>
-            <version>0.9.14</version>
+            <version>1.0.0</version>
             <scope>compile</scope>
         </dependency>
 
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>0.9.14</version>
+            <version>1.0.0</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
These changes update the documentation to point to the 1.0.0 versions of everything, as well as update the example command output within the installation instructions to match what would be produced by the upcoming 1.0.0 release.