### PR TITLE
GUACAMOLE-718: Correct slight grammatical error in TOTP chapter.

### DIFF
--- a/src/chapters/totp-auth.xml
+++ b/src/chapters/totp-auth.xml
@@ -77,8 +77,8 @@
         <section xml:id="totp-enrollment">
             <title>Enrollment</title>
             <para>If the user does not yet have a TOTP key associated with their account (they have
-                not yet completed enrollment), they be required to enroll an authentication device
-                after passing the first authentication factor. A QR code containing an
+                not yet completed enrollment), they will be required to enroll an authentication
+                device after passing the first authentication factor. A QR code containing an
                 automatically-generated key will be presented to the user to be scanned by their
                 authentication app or device:</para>
             <mediaobject>


### PR DESCRIPTION
Because we only should speak like that on Speak Like a Pirate Day.