### PR TITLE
GUACAMOLE-422: Document support for timezone handshake and parameter.

### DIFF
--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -2969,6 +2969,23 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                                     <para>For more information, please see <xref linkend="ssh-host-verification"/>.</para>
                                 </entry>
                             </row>
+                            <row>
+                                <entry><parameter>server-alive-interval</parameter></entry>
+                                <entry>
+                                    <para>
+                                        <indexterm>
+                                            <primary>SSH</primary>
+                                            <secondary>server-alive-interval</secondary>
+                                        </indexterm>
+                                        By default the SSH client does not send keepalive requests
+                                        to the server.  This parameter allows you to configure the
+                                        the interval in seconds at which the client connection
+                                        sends keepalive packets to the server.  The default is 0,
+                                        which disables sending the packets.  The minimum value
+                                        is 2.
+                                    </para>
+                                </entry>
+                            </row>
                         </tbody>
                     </tgroup>
                 </informaltable>
@@ -3224,9 +3241,13 @@ color9: rgb:80/00/80</programlisting>
                 </informaltable>
             </section>
             <section xml:id="ssh-command">
-                <title>Session parameters</title>
-                <para>The parameters in this section control various aspects
-                of the SSH session.</para>
+                <title>Running a command (instead of a shell)</title>
+                <para>By default, SSH sessions will start an interactive shell. The shell which will
+                    be used is determined by the SSH server, normally by reading the user's default
+                    shell previously set with <command>chsh</command> or within
+                        <filename>/etc/passwd</filename>. If you wish to override this and instead
+                    run a specific command, you can do so by specifying that command in the
+                    configuration of the Guacamole SSH connection.</para>
                 <informaltable frame="all">
                     <indexterm>
                         <primary>parameters</primary>
@@ -3248,71 +3269,9 @@ color9: rgb:80/00/80</programlisting>
                                     <para><indexterm>
                                             <primary>SSH</primary>
                                             <secondary>command</secondary>
-                                        </indexterm>By default, SSH sessions will
-                                        start an interactive shell.  The shell
-                                        that is used will be determined by the
-                                        SSH server, normally by reading the user's
-                                        default login shell specified in
-                                        <filename>/etc/passwd</filename>.  If you
-                                        wish to override this and run a specific
-                                        command, you can do so by filling in a
-                                        value for this parameter.  Assuming the
-                                        server allows arbitrary commands to be
-                                        run, the session will attempt to start
-                                        the specified command in place of the
-                                        shell.  This parameter is optional. If not specified, the SSH
+                                        </indexterm>The command to execute over the SSH session, if
+                                        any. This parameter is optional. If not specified, the SSH
                                         session will use the user's default shell.</para>
-                                </entry>
-                            </row>
-                            <row>
-                                <entry><parameter>timezone</parameter></entry>
-                                <entry>
-                                    <para>
-                                        <indexterm>
-                                            <primary>SSH</primary>
-                                            <secondary>timezone</secondary>
-                                        </indexterm>This parameter allows you
-                                        to control the timezone that is sent
-                                        to the server over the SSH connection,
-                                        which will change the way local time is
-                                        displayed on the server.</para>
-                                    <para>
-                                        The mechanism used to do this over SSH
-                                        connections is by setting the
-                                        <envar>TZ</envar> variable on the SSH
-                                        connection to the timezone specified by
-                                        this parameter.  This means that the SSH
-                                        server must allow the <envar>TZ</envar>
-                                        variable to be set/overriden - many SSH
-                                        server implementations have this disabled
-                                        by default.  To get this to work, you may
-                                        need to modify the configuration of the
-                                        SSH server and explicitly allow for
-                                        <envar>TZ</envar> to be set/overriden.
-                                    </para>
-                                    <para>
-                                        The available values of this parameter are
-                                        standard IANA key zone format timezones,
-                                        and the value will be sent directly to
-                                        the server in this format.
-                                    </para>
-                                </entry>
-                            </row>
-                            <row>
-                                <entry><parameter>server-alive-interval</parameter></entry>
-                                <entry>
-                                    <para>
-                                        <indexterm>
-                                            <primary>SSH</primary>
-                                            <secondary>server-alive-interval</secondary>
-                                        </indexterm>
-                                        By default the SSH client does not send keepalive requests
-                                        to the server.  This parameter allows you to configure the
-                                        the interval in seconds at which the client connection
-                                        sends keepalive packets to the server.  The default is 0,
-                                        which disables sending the packets.  The minimum value
-                                        is 2.
-                                    </para>
                                 </entry>
                             </row>
                         </tbody>
@@ -3355,6 +3314,40 @@ color9: rgb:80/00/80</programlisting>
                                         will only have an effect if the SSH server allows the
                                             <envar>LANG</envar> environment variable to be set by
                                         SSH clients.</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry><parameter>timezone</parameter></entry>
+                                <entry>
+                                    <para>
+                                        <indexterm>
+                                            <primary>SSH</primary>
+                                            <secondary>timezone</secondary>
+                                        </indexterm>This parameter allows you
+                                        to control the timezone that is sent
+                                        to the server over the SSH connection,
+                                        which will change the way local time is
+                                        displayed on the server.</para>
+                                    <para>
+                                        The mechanism used to do this over SSH
+                                        connections is by setting the
+                                        <envar>TZ</envar> variable on the SSH
+                                        connection to the timezone specified by
+                                        this parameter.  This means that the SSH
+                                        server must allow the <envar>TZ</envar>
+                                        variable to be set/overriden - many SSH
+                                        server implementations have this disabled
+                                        by default.  To get this to work, you may
+                                        need to modify the configuration of the
+                                        SSH server and explicitly allow for
+                                        <envar>TZ</envar> to be set/overriden.
+                                    </para>
+                                    <para>
+                                        The available values of this parameter are
+                                        standard IANA key zone format timezones,
+                                        and the value will be sent directly to
+                                        the server in this format.
+                                    </para>
                                 </entry>
                             </row>
                         </tbody>

--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -3279,16 +3279,16 @@ color9: rgb:80/00/80</programlisting>
                                     <para>
                                         The mechanism used to do this over SSH
                                         connections is by setting the
-                                        <envvar>TZ</envvar> variable on the SSH
+                                        <envar>TZ</envar> variable on the SSH
                                         connection to the timezone specified by
                                         this parameter.  This means that the SSH
-                                        server must allow the <envvar>TZ</envvar>
+                                        server must allow the <envar>TZ</envar>
                                         variable to be set/overriden - many SSH
                                         server implementations have this disabled
                                         by default.  To get this to work, you may
                                         need to modify the configuration of the
                                         SSH server and explicitly allow for
-                                        <envvar>TZ</envvar> to be set/overriden.
+                                        <envar>TZ</envar> to be set/overriden.
                                     </para>
                                     <para>
                                         The available values of this parameter are

--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -1783,7 +1783,7 @@ tcp6       0      0 :::4713                 :::*                    LISTEN</comp
                                     admin mode, along with Windows workstation
                                     versions, do not allow the timezone to be
                                     forwarded.  Other server implementations,
-                                    for example, xRDP, may not implement this
+                                    for example, xrdp, may not implement this
                                     feature at all.  Consult the documentation
                                     for the RDP server to determine whether or
                                     not this feature is supported.</para>

--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -1761,18 +1761,16 @@ tcp6       0      0 :::4713                 :::*                    LISTEN</comp
                                     used in UNIX/Linux.  This will be converted
                                     by RDP into the correct format for Windows.
                                     </para>
-                                    <para>Beginning with version 1.1.0 of
-                                    Guacamole, the timezone is detected and,
-                                    assuming that guacd is at version 1.1.0 or
-                                    greater, this will be passed to the server
-                                    and used by protocols, like RDP, that
-                                    support it.  This parameter can be used to
-                                    override the value detected and passed
-                                    during the handshake, or can be used in
-                                    situations where guacd does not support
-                                    passing the timezone parameter during the
-                                    handshake phase (guacd versions prior to
-                                    1.1.0).</para>
+                                    <para>The timezone is detected and will be
+                                    passed to the server during the handshake
+                                    phase of the connection, and may used by
+                                    protocols, like RDP, that support it.  This
+                                    parameter can be used to override the value
+                                    detected and passed during the handshake, or
+                                    can be used in situations where guacd does
+                                    not support passing the timezone parameter
+                                    during the handshake phase (guacd versions
+                                    prior to 1.1.0).</para>
                                     <para>Support for forwarding the client
                                     timezone varies by RDP server implementation.
                                     For example, with Windows, support for

--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -1747,6 +1747,48 @@ tcp6       0      0 :::4713                 :::*                    LISTEN</comp
                                     </variablelist>
                                 </entry>
                             </row>
+                            <row>
+                                <entry><parameter>timezone</parameter></entry>
+                                <entry>
+                                    <para><indexterm>
+                                            <primary>RDP</primary>
+                                            <secondary>timezone</secondary>
+                                        </indexterm>The timezone that the client
+                                    should send to the server for configuring the
+                                    local time display of that server.  The
+                                    format of the timezone is in the standard
+                                    IANA key zone format, which is the format
+                                    used in UNIX/Linux.  This will be converted
+                                    by RDP into the correct format for Windows.
+                                    </para>
+                                    <para>Beginning with version 1.1.0 of
+                                    Guacamole, the timezone is detected and,
+                                    assuming that guacd is at version 1.1.0 or
+                                    greater, this will be passed to the server
+                                    and used by protocols, like RDP, that
+                                    support it.  This parameter can be used to
+                                    override the value detected and passed
+                                    during the handshake, or can be used in
+                                    situations where guacd does not support
+                                    passing the timezone parameter during the
+                                    handshake phase (guacd versions prior to
+                                    1.1.0).</para>
+                                    <para>Support for forwarding the client
+                                    timezone varies by RDP server implementation.
+                                    For example, with Windows, support for
+                                    forwarding timezones is only present in
+                                    Windows Server with Remote Desktop Services
+                                    (RDS, formerly known as Terminal Services)
+                                    installed.  Windows Server installations in
+                                    admin mode, along with Windows workstation
+                                    versions, do not allow the timezone to be
+                                    forwarded.  Other server implementations,
+                                    for example, xRDP, may not implement this
+                                    feature at all.  Consult the documentation
+                                    for the RDP server to determine whether or
+                                    not this feature is supported.</para>
+                                </entry>
+                            </row>
                         </tbody>
                     </tgroup>
                 </informaltable>
@@ -2929,23 +2971,6 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                                     <para>For more information, please see <xref linkend="ssh-host-verification"/>.</para>
                                 </entry>
                             </row>
-                            <row>
-                                <entry><parameter>server-alive-interval</parameter></entry>
-                                <entry>
-                                    <para>
-                                        <indexterm>
-                                            <primary>SSH</primary>
-                                            <secondary>server-alive-interval</secondary>
-                                        </indexterm>
-                                        By default the SSH client does not send keepalive requests
-                                        to the server.  This parameter allows you to configure the
-                                        the interval in seconds at which the client connection
-                                        sends keepalive packets to the server.  The default is 0,
-                                        which disables sending the packets.  The minimum value
-                                        is 2.
-                                    </para>
-                                </entry>
-                            </row>
                         </tbody>
                     </tgroup>
                 </informaltable>
@@ -3201,13 +3226,9 @@ color9: rgb:80/00/80</programlisting>
                 </informaltable>
             </section>
             <section xml:id="ssh-command">
-                <title>Running a command (instead of a shell)</title>
-                <para>By default, SSH sessions will start an interactive shell. The shell which will
-                    be used is determined by the SSH server, normally by reading the user's default
-                    shell previously set with <command>chsh</command> or within
-                        <filename>/etc/passwd</filename>. If you wish to override this and instead
-                    run a specific command, you can do so by specifying that command in the
-                    configuration of the Guacamole SSH connection.</para>
+                <title>Session parameters</title>
+                <para>The parameters in this section control various aspects
+                of the SSH session.</para>
                 <informaltable frame="all">
                     <indexterm>
                         <primary>parameters</primary>
@@ -3229,9 +3250,71 @@ color9: rgb:80/00/80</programlisting>
                                     <para><indexterm>
                                             <primary>SSH</primary>
                                             <secondary>command</secondary>
-                                        </indexterm>The command to execute over the SSH session, if
-                                        any. This parameter is optional. If not specified, the SSH
+                                        </indexterm>By default, SSH sessions will
+                                        start an interactive shell.  The shell
+                                        that is used will be determined by the
+                                        SSH server, normally by reading the user's
+                                        default login shell specified in
+                                        <filename>/etc/passwd</filename>.  If you
+                                        wish to override this and run a specific
+                                        command, you can do so by filling in a
+                                        value for this parameter.  Assuming the
+                                        server allows arbitrary commands to be
+                                        run, the session will attempt to start
+                                        the specified command in place of the
+                                        shell.  This parameter is optional. If not specified, the SSH
                                         session will use the user's default shell.</para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry><parameter>timezone</parameter></entry>
+                                <entry>
+                                    <para>
+                                        <indexterm>
+                                            <primary>SSH</primary>
+                                            <secondary>timezone</secondary>
+                                        </indexterm>This parameter allows you
+                                        to control the timezone that is sent
+                                        to the server over the SSH connection,
+                                        which will change the way local time is
+                                        displayed on the server.</para>
+                                    <para>
+                                        The mechanism used to do this over SSH
+                                        connections is by setting the
+                                        <envvar>TZ</envvar> variable on the SSH
+                                        connection to the timezone specified by
+                                        this parameter.  This means that the SSH
+                                        server must allow the <envvar>TZ</envvar>
+                                        variable to be set/overriden - many SSH
+                                        server implementations have this disabled
+                                        by default.  To get this to work, you may
+                                        need to modify the configuration of the
+                                        SSH server and explicitly allow for
+                                        <envvar>TZ</envvar> to be set/overriden.
+                                    </para>
+                                    <para>
+                                        The available values of this parameter are
+                                        standard IANA key zone format timezones,
+                                        and the value will be sent directly to
+                                        the server in this format.
+                                    </para>
+                                </entry>
+                            </row>
+                            <row>
+                                <entry><parameter>server-alive-interval</parameter></entry>
+                                <entry>
+                                    <para>
+                                        <indexterm>
+                                            <primary>SSH</primary>
+                                            <secondary>server-alive-interval</secondary>
+                                        </indexterm>
+                                        By default the SSH client does not send keepalive requests
+                                        to the server.  This parameter allows you to configure the
+                                        the interval in seconds at which the client connection
+                                        sends keepalive packets to the server.  The default is 0,
+                                        which disables sending the packets.  The minimum value
+                                        is 2.
+                                    </para>
                                 </entry>
                             </row>
                         </tbody>

--- a/src/chapters/protocol.xml
+++ b/src/chapters/protocol.xml
@@ -67,7 +67,42 @@
             supported version and enable or disable features associated with that version.
             Older versions of the Guacamole Client that do not support this instruction
             will silently ignore it as an empty connection parameter.  Valid protocol versions
-            are <constant>VERSION_1_0_0</constant> (1.0.0 and earlier) and 
+            are as follows:<informaltable frame="all">
+                <tgroup cols="3">
+                    <colspec colname="c1" colnum="1" colwidth="1.25*"/>
+                    <colspec colname="c2" colnum="2" colwidth="3.25*"/>
+                    <colspec colname="c3" colnum="3" colwidth="9*"/>
+                    <thead>
+                        <row>
+                            <entry>Version</entry>
+                            <entry>Value</entry>
+                            <entry>Description</entry>
+                        </row>
+                    </thead>
+                    <tbody>
+                        <row>
+                            <entry>1.0.0</entry>
+                            <entry><constant>VERSION_1_0_0</constant></entry>
+                            <entry>This is the defualt version and applies to any
+                            versions prior to 1.1.0.  Version 1.0.0 of the protocol
+                            does not support protocol negotiation, and requires that
+                            the handshake instructions are delivered in a certain
+                            order, and that they are present (even if empty).</entry>
+                        </row>
+                        <row>
+                            <entry>1.1.0</entry>
+                            <entry><constant>VERSION_1_1_0</constant></entry>
+                            <entry>Protocol version 1.1.0 introduces support for
+                            protocol version negotiation, arbitrary order of the
+                            handshake instructions, and support for passing the
+                            timezone instruction during the handshake.</entry>
+                        </row>
+                    </tbody>
+                </tgroup>
+            </informaltable>
+        </para>
+        
+                <constant>VERSION_1_0_0</constant> (1.0.0 and earlier) and 
             <constant>VERSION_1_1_0</constant> (1.1.0).</para>
         <para>After receiving the list of arguments, the client is required to respond with the list
             of supported audio, video, and image mimetypes, the optimal display size and resolution,

--- a/src/chapters/protocol.xml
+++ b/src/chapters/protocol.xml
@@ -124,9 +124,11 @@
                     <row>
                         <entry><parameter>timezone</parameter></entry>
                         <entry><para>The timezone of the client, in IANA zone key format.  More
-                            information on this instruction is available in <xref linkend="configuring"/>,
-                            under documentation related to the <constant>timezone</constant>
-                            connection parameters for the protocols that support it.</para></entry>
+                            information on this instruction is available in
+                            <xref linkend="configuring-guacamole"/>, under documentation related
+                            to the <constant>timezone</constant> connection parameters for the
+                            protocols that support it.</para>
+                        </entry>
                     </row>
                     <row>
                         <entry><parameter>video</parameter></entry>

--- a/src/chapters/protocol.xml
+++ b/src/chapters/protocol.xml
@@ -80,6 +80,22 @@
             it supports Ogg Vorbis audio, but no video, and can accept both PNG and JPEG images. It
             wants to connect to localhost at port 5900, and is leaving the three other parameters
             blank.</para>
+        <para>Version 1.1.0 of Guacamole adds a couple of other features to the handshake phase.  First,
+            the handshake can now be done with most of the handshake instructions sent in arbitrary order.
+            Beginning with this version, guacd will detect and parse out each of the options regardless
+            of the order they are sent in, looking for the connect instruction as the indication
+            that the client has finished sending options.  In addition to ordering, this means
+            that certain instructions can be omitted without preventing the connection from
+            continuing.
+        </para>
+        <para>Also introduced in version 1.1.0 is the ability to pass the client timezone to
+            guacd, which can be used by protocols that support it to alter how the server
+            displays local time for the logged in user.  More information on this is available
+            in <xref linkend="configuring"/>, under the documentation related to
+            the timezone parameter.  If either the client or server do not support the
+            timezone instruction in the handshake the information will not be pased and the
+            connection will continue.
+        </para>
         <para>Once these instructions have been sent by the client, the server will attempt to
             initialize the connection with the parameters received and, if successful, respond with
             a "ready" instruction. This instruction contains the ID of the new client connection and

--- a/src/chapters/protocol.xml
+++ b/src/chapters/protocol.xml
@@ -57,45 +57,88 @@
             <programlisting>6.select,3.vnc;</programlisting>
         </informalexample>
         <para>After receiving the "select" instruction, the server will load the associated client
-            support and respond with a list of accepted parameter names using an "args"
-            instruction:</para>
+            support and respond with its protocol version and a list of accepted parameter names
+            using an "args" instruction:</para>
         <informalexample>
-            <programlisting>4.args,8.hostname,4.port,8.password,13.swap-red-blue,9.read-only;</programlisting>
+            <programlisting>4.args,13.VERSION_1_1_0,8.hostname,4.port,8.password,13.swap-red-blue,9.read-only;</programlisting>
         </informalexample>
+        <para>The protocol version is used to negotiate compatibility between differing
+            versions of client and server, allowing the two sides to negotiate the highest
+            supported version and enable or disable features associated with that version.
+            Older versions of the Guacamole Client that do not support this instruction
+            will silently ignore it as an empty connection parameter.  Valid protocol versions
+            are <constant>VERSION_1_0_0</constant> (1.0.0 and earlier) and 
+            <constant>VERSION_1_1_0</constant> (1.1.0).</para>
         <para>After receiving the list of arguments, the client is required to respond with the list
             of supported audio, video, and image mimetypes, the optimal display size and resolution,
-            and the values for all arguments available, even if blank. If any of these requirements
-            are left out, the connection will close:</para>
+            and the values for all arguments available, even if blank.</para>
         <informalexample>
             <programlisting>4.size,4.1024,3.768,2.96;
 5.audio,9.audio/ogg;
 5.video;
 5.image,9.image/png,10.image/jpeg;
+8.timezone,16.America/New_York;
 7.connect,9.localhost,4.5900,0.,0.,0.;</programlisting>
         </informalexample>
         <para>For clarity, we've put each instruction on its own line, but in the real protocol, no
             newlines exist between instructions. In fact, if there is anything after an instruction
             other than the start of a new instruction, the connection is closed.</para>
-        <para>Here, the client is specifying that the optimal display size is 1024x768 at 96 DPI and
-            it supports Ogg Vorbis audio, but no video, and can accept both PNG and JPEG images. It
-            wants to connect to localhost at port 5900, and is leaving the three other parameters
-            blank.</para>
-        <para>Version 1.1.0 of Guacamole adds a couple of other features to the handshake phase.  First,
-            the handshake can now be done with most of the handshake instructions sent in arbitrary order.
-            Beginning with this version, guacd will detect and parse out each of the options regardless
-            of the order they are sent in, looking for the connect instruction as the indication
-            that the client has finished sending options.  In addition to ordering, this means
-            that certain instructions can be omitted without preventing the connection from
-            continuing.
-        </para>
-        <para>Also introduced in version 1.1.0 is the ability to pass the client timezone to
-            guacd, which can be used by protocols that support it to alter how the server
-            displays local time for the logged in user.  More information on this is available
-            in <xref linkend="configuring"/>, under the documentation related to
-            the timezone parameter.  If either the client or server do not support the
-            timezone instruction in the handshake the information will not be pased and the
-            connection will continue.
-        </para>
+        <para>The following are valid instructions during the handshake:</para>
+        <informaltable frame="all">
+            <indexterm>
+                <primary>handshake</primary>
+                <secondary>instructions</secondary>
+            </indexterm>
+            <tgroup cols="2">
+                <colspec colname="c1" colnum="1" colwidth="1*"/>
+                <colspec colname="c2" colnum="2" colwidth="3.55*"/>
+                <thead>
+                    <row>
+                        <entry>Instruction name</entry>
+                        <entry>Description</entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row>
+                        <entry><parameter>audio</parameter></entry>
+                        <entry><para>The audio codec(s) supported by the client.  In the example
+                            above the client is specifying audio/ogg as the supported codec.</para>
+                        </entry>
+                    </row>
+                    <row>
+                        <entry><parameter>connect</parameter></entry>
+                        <entry><para>This is the final instruction of the handshake, terminating
+                            the handshake and indicating that the connection should continue.
+                            This instruction has as its parameters values for the connection
+                            parameters sent by the server in the <constant>args</constant>
+                            instruction.  In the example above, this is connection to localhost
+                            on port 5900, with no values for the last three connection parameters.
+                        </para></entry>
+                    </row>
+                    <row>
+                        <entry><parameter>image</parameter></entry>
+                        <entry><para>The image formats that the client supports, in order of
+                            preference.  The client in the example above is supporting both PNG
+                            and JPEG.</para></entry>
+                    </row>
+                    <row>
+                        <entry><parameter>timezone</parameter></entry>
+                        <entry><para>The timezone of the client, in IANA zone key format.  More
+                            information on this instruction is available in <xref linkend="configuring"/>,
+                            under documentation related to the <constant>timezone</constant>
+                            connection parameters for the protocols that support it.</para></entry>
+                    </row>
+                    <row>
+                        <entry><parameter>video</parameter></entry>
+                        <entry><para>The video codec(s) supported by the client.  The above example
+                            is a client that does not support any video codecs.</para></entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </informaltable>
+        <para>The order of the instructions sent by the client in the handshake is arbitrary, with
+            the exception that the final instruction, connect, will end the handshake and attempt
+            to start the connection.</para>
         <para>Once these instructions have been sent by the client, the server will attempt to
             initialize the connection with the parameters received and, if successful, respond with
             a "ready" instruction. This instruction contains the ID of the new client connection and

--- a/src/chapters/protocol.xml
+++ b/src/chapters/protocol.xml
@@ -105,12 +105,13 @@
             of supported audio, video, and image mimetypes, the optimal display size and resolution,
             and the values for all arguments available, even if blank.</para>
         <informalexample>
-            <programlisting>4.size,4.1024,3.768,2.96;
+            <programlisting>
+4.size,4.1024,3.768,2.96;
 5.audio,9.audio/ogg;
 5.video;
 5.image,9.image/png,10.image/jpeg;
 8.timezone,16.America/New_York;
-7.connect,9.localhost,4.5900,0.,0.,0.;</programlisting>
+7.connect,13.VERSION_1_1_0,9.localhost,4.5900,0.,0.,0.;</programlisting>
         </informalexample>
         <para>For clarity, we've put each instruction on its own line, but in the real protocol, no
             newlines exist between instructions. In fact, if there is anything after an instruction

--- a/src/chapters/protocol.xml
+++ b/src/chapters/protocol.xml
@@ -83,7 +83,7 @@
                         <row>
                             <entry>1.0.0</entry>
                             <entry><constant>VERSION_1_0_0</constant></entry>
-                            <entry>This is the defualt version and applies to any
+                            <entry>This is the default version and applies to any
                             versions prior to 1.1.0.  Version 1.0.0 of the protocol
                             does not support protocol negotiation, and requires that
                             the handshake instructions are delivered in a certain
@@ -101,9 +101,6 @@
                 </tgroup>
             </informaltable>
         </para>
-        
-                <constant>VERSION_1_0_0</constant> (1.0.0 and earlier) and 
-            <constant>VERSION_1_1_0</constant> (1.1.0).</para>
         <para>After receiving the list of arguments, the client is required to respond with the list
             of supported audio, video, and image mimetypes, the optimal display size and resolution,
             and the values for all arguments available, even if blank.</para>

--- a/src/references/instructions/client/handshake/audio.xml
+++ b/src/references/instructions/client/handshake/audio.xml
@@ -9,6 +9,5 @@
     </indexterm>
     <para>Specifies which audio mimetypes are supported by the client. Each
         parameter must be a single mimetype, listed in order of client
-        preference, with the optimal mimetype being the first parameter. This is
-        the third instruction sent during the handshake phase.</para>
+        preference, with the optimal mimetype being the first parameter.</para>
 </section>

--- a/src/references/instructions/client/handshake/image.xml
+++ b/src/references/instructions/client/handshake/image.xml
@@ -8,7 +8,7 @@
     </indexterm>
     <para>Specifies which image mimetypes are supported by the client. Each parameter must be a
         single mimetype, listed in order of client preference, with the optimal mimetype being the
-        first parameter. This is the fifth instruction sent during the handshake phase.</para>
+        first parameter.</para>
     <para>It is expected that the supported mimetypes will include at least "image/png" and
         "image/jpeg", and the server <emphasis>may</emphasis> safely assume that these mimetypes are
         supported, even if they are absent from the handshake.</para>

--- a/src/references/instructions/client/handshake/size.xml
+++ b/src/references/instructions/client/handshake/size.xml
@@ -7,8 +7,7 @@
     <indexterm>
         <primary>size</primary>
     </indexterm>
-    <para>Specifies the client's optimal screen size and resolution. This is the second instruction
-        sent during the handshake phase.</para>
+    <para>Specifies the client's optimal screen size and resolution.</para>
     <variablelist>
         <varlistentry>
             <term><parameter>width</parameter></term>

--- a/src/references/instructions/client/handshake/timezone.xml
+++ b/src/references/instructions/client/handshake/timezone.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<section xml:id="timezone-handshake-instruction"
+    xmlns="http://docbook.org/ns/docbook" version="5.0" xml:lang="en"
+    xmlns:xi="http://www.w3.org/2001/XInclude">
+    <title>timezone</title>
+    <indexterm>
+        <primary>timezone</primary>
+    </indexterm>
+    <para>Specifies the timezone of the client system, in IANA zone key format.
+        This is a single-value parameter, and may be used by protocols to
+        set the timezone on the remote computer, if the remote system allows
+        the timezone to be configured.  This instruction is optional.</para>
+</section>

--- a/src/references/instructions/client/handshake/timezone.xml
+++ b/src/references/instructions/client/handshake/timezone.xml
@@ -11,4 +11,13 @@
         This is a single-value parameter, and may be used by protocols to
         set the timezone on the remote computer, if the remote system allows
         the timezone to be configured.  This instruction is optional.</para>
+    <variablelist>
+        <varlistentry>
+            <term><parameter>timezone</parameter></term>
+            <listiem>
+                <para>A valid IANA time zone key that indicates the time zone
+                that the client is currently using.</para>
+            </listiem>
+        </varlistentry>
+    </variablelist>
 </section>

--- a/src/references/instructions/client/handshake/video.xml
+++ b/src/references/instructions/client/handshake/video.xml
@@ -9,6 +9,5 @@
     </indexterm>
     <para>Specifies which video mimetypes are supported by the client. Each
         parameter must be a single mimetype, listed in order of client
-        preference, with the optimal mimetype being the first parameter. This is
-        the fourth instruction sent during the handshake phase.</para>
+        preference, with the optimal mimetype being the first parameter.</para>
 </section>

--- a/src/references/instructions/server/handshake/args.xml
+++ b/src/references/instructions/server/handshake/args.xml
@@ -13,8 +13,8 @@
         supported by the server.  This is used to negotiate protocol
         compatibility between the client and the server, with the highest
         supported protocol by both sides being chosen.  Versions of Guacamole
-        prior to 1.1.0 do not support this instruction and cannot
-        negotiate this compatibility.</para>
+        prior to 1.1.0 do not support protocol version negotiation, and will
+        silently ignore this instruction.</para>
     <para>The remaining parameters of the args instruction are the names of all
         connection parameters accepted by the server for the protocol selected
         by the client, in order. The client's responding connect instruction

--- a/src/references/instructions/server/handshake/args.xml
+++ b/src/references/instructions/server/handshake/args.xml
@@ -9,9 +9,16 @@
     <para>Reports the expected format of the argument list for the protocol
         requested by the client. This message can be sent by the server during
         the handshake phase only.</para>
-    <para>The parameters of the args instruction are the names of all parameters
-        accepted by the server for the protocol in selected by the client, in
-        order. The client's responding connect instruction must the values of
-        each of these parameters in the same order.</para>
+    <para>The first parameter of this instruction will be the protocol version
+        supported by the server.  This is used to negotiate protocol
+        compatibility between the client and the server, with the highest
+        supported protocol by both sides being chosen.  Versions of Guacamole
+        prior to 1.1.0 do not support this instruction and cannot
+        negotiate this compatibility.</para>
+    <para>The remaining parameters of the args instruction are the names of all
+        connection parameters accepted by the server for the protocol selected
+        by the client, in order. The client's responding connect instruction
+        must contain the values of each of these parameters in the same order.
+    </para>
 
 </section>

--- a/src/references/protocol.xml
+++ b/src/references/protocol.xml
@@ -80,6 +80,7 @@
         <xi:include href="instructions/client/handshake/image.xml"/>
         <xi:include href="instructions/client/handshake/select.xml"/>
         <xi:include href="instructions/client/handshake/size.xml"/>
+        <xi:include href="instructions/client/handshake/timezone.xml"/>
         <xi:include href="instructions/client/handshake/video.xml"/>
     </section>
     <section xml:id="server-handshake-instructions">


### PR DESCRIPTION
A few items covered by this pull request:
* Document the timezone parameters for SSH and RDP
* Rearrange SSH documentation to match how parameters are currently configured.
* Document the timezone portion of the handshake, along with some notes about how instructions can now be in arbitrary order during the handshake phase.

I'm sure it needs some work, particularly the protocol/handshake section.