### PR TITLE
GUACAMOLE-354: Document de-ch-qwertz layout for RDP.

### DIFF
--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -1673,6 +1673,12 @@ tcp6       0      0 :::4713                 :::*                    LISTEN</comp
                                             </listitem>
                                         </varlistentry>
                                         <varlistentry>
+                                            <term><constant>de-ch-qwertz</constant></term>
+                                            <listitem>
+                                                <para>German (Swiss) keyboard (qwertz)</para>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
                                             <term><constant>de-de-qwertz</constant></term>
                                             <listitem>
                                                 <para>German keyboard (qwertz)</para>
@@ -1687,7 +1693,7 @@ tcp6       0      0 :::4713                 :::*                    LISTEN</comp
                                         <varlistentry>
                                             <term><constant>fr-ch-qwertz</constant></term>
                                             <listitem>
-                                                <para>Swiss French keyboard (qwertz)</para>
+                                                <para>French (Swiss) keyboard (qwertz)</para>
                                             </listitem>
                                         </varlistentry>
                                         <varlistentry>

--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -1675,7 +1675,7 @@ tcp6       0      0 :::4713                 :::*                    LISTEN</comp
                                         <varlistentry>
                                             <term><constant>de-ch-qwertz</constant></term>
                                             <listitem>
-                                                <para>German (Swiss) keyboard (qwertz)</para>
+                                                <para>Swiss German keyboard (qwertz)</para>
                                             </listitem>
                                         </varlistentry>
                                         <varlistentry>
@@ -1693,7 +1693,7 @@ tcp6       0      0 :::4713                 :::*                    LISTEN</comp
                                         <varlistentry>
                                             <term><constant>fr-ch-qwertz</constant></term>
                                             <listitem>
-                                                <para>French (Swiss) keyboard (qwertz)</para>
+                                                <para>Swiss French keyboard (qwertz)</para>
                                             </listitem>
                                         </varlistentry>
                                         <varlistentry>


### PR DESCRIPTION
Document the German (Swiss) keyboard layout setting for RDP.