### PR TITLE
GUACAMOLE-837: Add RDP keymap for Hungarian keyboard layout

### DIFF
--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -1747,6 +1747,12 @@ tcp6       0      0 :::4713                 :::*                    LISTEN</comp
                                             </listitem>
                                         </varlistentry>
                                         <varlistentry>
+                                            <term><constant>hu-hu-qwertz</constant></term>
+                                            <listitem>
+                                                <para>Hungarian keyboard (qwertz)</para>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
                                             <term><constant>it-it-qwerty</constant></term>
                                             <listitem>
                                                 <para>Italian keyboard</para>


### PR DESCRIPTION
Updated documentation to include the new keyboard layout in configure section.