### PR TITLE
GUACAMOLE-912: Guacamole Docker image does not support Docker Links for LDAP

### DIFF
--- a/src/chapters/docker.xml
+++ b/src/chapters/docker.xml
@@ -652,7 +652,7 @@
             <title>LDAP authentication</title>
             <para>To use Guacamole with the LDAP authentication backend, you will need network
                 access to an LDAP directory. Unlike MySQL and PostgreSQL, the Guacamole Docker image
-                does support Docker links for LDAP; the connection information
+                does not support Docker links for LDAP; the connection information
                     <emphasis>must</emphasis> be specified using environment variables:</para>
             <informaltable frame="all">
                 <tgroup cols="2">


### PR DESCRIPTION
GUACAMOLE-912: Guacamole Docker image does not support Docker Links for LDAP. Fixed logical error in documentation to clarify that Guacamole Docker image does not support Docker Links.