### PR TITLE
GUACAMOLE-249: Update documentation with respect to FreeRDP 2.x support.

### DIFF
--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -1430,15 +1430,20 @@ tcp6       0      0 :::4713                 :::*                    LISTEN</comp
             <section xml:id="rdp-authentication">
                 <title>Authentication and security</title>
                 <para>RDP provides authentication through the use of a username, password, and
-                    optional domain.</para>
+                    optional domain. All RDP connections are encrypted.</para>
                 <para>Most RDP servers will provide a graphical login if the username, password, and
                     domain parameters are omitted. One notable exception to this is Network Level
                     Authentication, or NLA, which performs all authentication outside of a desktop
-                    session, and thus in the absence of a graphical interface. If your server
-                    requires NLA, you will need to manually choose this as your security mode, and
-                    you <emphasis>must</emphasis> provide a username and password.</para>
-                <para>All RDP connections are encrypted. Higher-grade encryption is available in the
-                    form of TLS, another possible security mode.</para>
+                    session, and thus in the absence of a graphical interface.</para>
+                <important>
+                    <para>If your server requires NLA, you <emphasis>must</emphasis> provide a
+                        username and password. Leveraging Guacamole's <link
+                            xmlns:xlink="http://www.w3.org/1999/xlink" linkend="parameter-tokens"
+                            >parameter tokens</link> and <link
+                            xmlns:xlink="http://www.w3.org/1999/xlink" linkend="ldap-auth">LDAP
+                            support</link> to integrate with Active Directory and automatically pass
+                        through credentials is a common configuration.</para>
+                </important>
                 <informaltable frame="all">
                     <indexterm>
                         <primary>parameters</primary>
@@ -1498,42 +1503,68 @@ tcp6       0      0 :::4713                 :::*                    LISTEN</comp
                                             <secondary>TLS</secondary>
                                         </indexterm>The security mode to use for the RDP connection.
                                         This mode dictates how data will be encrypted and what type
-                                        of authentication will be performed, if any. By default,
-                                        standard RDP encryption is requested, as it is the most
-                                        widely supported.</para>
+                                        of authentication will be performed, if any. By default, a
+                                        security mode is selected based on a negotiation process
+                                        which determines what both the client and the server
+                                        support.</para>
                                     <para>Possible values are:</para>
                                     <variablelist>
                                         <varlistentry>
-                                            <term><constant>rdp</constant></term>
+                                            <term><constant>any</constant></term>
                                             <listitem>
-                                                <para>Standard RDP encryption. <emphasis>This is the
-                                                  default</emphasis> and should be supported by all
-                                                  RDP servers.</para>
+                                                <para>Automatically select the security mode based
+                                                  on the security protocols supported by both the
+                                                  client and the server. <emphasis>This is the
+                                                  default</emphasis>.</para>
                                             </listitem>
                                         </varlistentry>
                                         <varlistentry>
                                             <term><constant>nla</constant></term>
                                             <listitem>
-                                                <para>Network Level Authentication. This mode
-                                                  requires the username and password, and performs
-                                                  an authentication step before the remote desktop
-                                                  session actually starts. If the username and
-                                                  password are not given, the connection cannot be
-                                                  made.</para>
+                                                <para>Network Level Authentication, sometimes also
+                                                  referred to as "hybrid" or CredSSP (the protocol
+                                                  that drives NLA). This mode uses TLS encryption
+                                                  and requires the username and password to be given
+                                                  in advance. Unlike RDP mode, the authentication
+                                                  step is performed before the remote desktop
+                                                  session actually starts, avoiding the need for the
+                                                  Windows server to allocate significant resources
+                                                  for users that may not be authorized.</para>
+                                            </listitem>
+                                        </varlistentry>
+                                        <varlistentry>
+                                            <term><constant>nla-ext</constant></term>
+                                            <listitem>
+                                                <para>Extended Network Level Authentication. This
+                                                  mode is identical to NLA except that an additional
+                                                  "<link xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                  xlink:href="https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/d0e560a3-25cb-4563-8bdc-6c4cc625bbfc"
+                                                  >Early User Authorization Result</link>" is
+                                                  required to be sent from the server to the client
+                                                  immediately after the NLA handshake is
+                                                  completed.</para>
                                             </listitem>
                                         </varlistentry>
                                         <varlistentry>
                                             <term><constant>tls</constant></term>
                                             <listitem>
-                                                <para>TLS encryption. TLS (Transport Layer Security)
-                                                  is the successor to SSL.</para>
+                                                <para>RDP authentication and encryption implemented
+                                                  via TLS (Transport Layer Security). Also referred
+                                                  to as RDSTLS, the TLS security mode is primarily
+                                                  used in load balanced configurations where the
+                                                  initial RDP server may redirect the connection to
+                                                  a different RDP server.</para>
                                             </listitem>
                                         </varlistentry>
                                         <varlistentry>
-                                            <term><constant>any</constant></term>
+                                            <term><constant>rdp</constant></term>
                                             <listitem>
-                                                <para>Allow the server to choose the type of
-                                                  security.</para>
+                                                <para>Standard RDP encryption. This mode is
+                                                  generally only used for older Windows servers or
+                                                  in cases where a standard Windows login screen is
+                                                  desired. Newer versions of Windows have this mode
+                                                  disabled by default and will only accept NLA
+                                                  unless explicitly configured otherwise.</para>
                                             </listitem>
                                         </varlistentry>
                                     </variablelist>

--- a/src/chapters/configuring.xml
+++ b/src/chapters/configuring.xml
@@ -2371,9 +2371,6 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                     connect through such a gateway, you will need to provide additional parameters
                     describing the connection to that gateway, as well as any required
                     credentials.</para>
-                <para><emphasis>This functionality is only available if Guacamole was built against
-                        FreeRDP 1.1 or later.</emphasis> Older versions of FreeRDP do not have
-                    support for RDP gateways.</para>
                 <informaltable frame="all">
                     <indexterm>
                         <primary>parameters</primary>
@@ -2408,9 +2405,6 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                                         </indexterm>The port of the remote desktop gateway that
                                         should be used as an intermediary for the remote desktop
                                         connection. By default, this will be "443".</para>
-                                    <para><emphasis>If using a version of FreeRDP prior to 1.2, this
-                                            setting has no effect.</emphasis> Older versions of
-                                        FreeRDP use a hard-coded value of "443". </para>
                                 </entry>
                             </row>
                             <row>
@@ -2466,10 +2460,6 @@ ed272546-87bd-4db9-acba-e36e1a9ca20a
                     files for convenience, look through the contents of those files for a string
                     field called "loadbalanceinfo", as that field is where the required
                     information/cookie would be specified.</para>
-                <para><emphasis>This functionality is only available if Guacamole was built against
-                        FreeRDP 1.1 or later.</emphasis> Older versions of FreeRDP do not have
-                    support for load balancers which require additional information during the
-                    connection process.</para>
                 <informaltable frame="all">
                     <indexterm>
                         <primary>parameters</primary>

--- a/src/chapters/installing.xml
+++ b/src/chapters/installing.xml
@@ -353,7 +353,7 @@
                                         <tbody>
                                             <row>
                                                 <entry>Debian / Ubuntu package</entry>
-                                                <entry><package>libfreerdp-dev</package></entry>
+                                                <entry><package>freerdp2-dev</package></entry>
                                             </row>
                                             <row>
                                                 <entry>Fedora / CentOS / RHEL package</entry>
@@ -672,7 +672,7 @@ guacamole-server version 1.1.0
 
    Library status:
 
-     freerdp ............. yes
+     freerdp2 ............ yes
      pango ............... yes
      libavcodec .......... yes
      libavutil ........... yes

--- a/src/chapters/installing.xml
+++ b/src/chapters/installing.xml
@@ -344,8 +344,9 @@
                         <row>
                             <entry><link xl:href="http://www.freerdp.com/">FreeRDP</link></entry>
                             <entry>
-                                <para>FreeRDP is required for RDP support. If you do not wish to
-                                    build RDP support, this library is not needed.</para>
+                                <para>FreeRDP 2.0.0 or later is required for RDP support. If you do
+                                    not wish to build RDP support, this library is not
+                                    needed.</para>
                                 <informaltable frame="none" rowheader="firstcol">
                                     <tgroup cols="2">
                                         <colspec colname="c1" colnum="1" colwidth="1.0*"/>

--- a/src/chapters/troubleshooting.xml
+++ b/src/chapters/troubleshooting.xml
@@ -427,22 +427,30 @@ guacd[19666]: Listening on host 127.0.0.1, port 4823</screen>
                     connection in use and try again.</para>
             </section>
             <section>
-                <title>Failed to load cliprdr plugin</title>
-                <para>FreeRDP provides a plugin called "cliprdr" which provides
-                    clipboard support for RDP. libguac-client-rdp loads this
-                    plugin in order to support clipboard, as well. If this
-                    plugin could not be loaded, then clipboard support will not
-                    be available, and the reason will be logged.</para>
+                <title>Support for the CLIPRDR channel (clipboard redirection) could not be
+                    loaded</title>
+                <para>FreeRDP provides a plugin which provides clipboard support for RDP. This
+                    plugin is typically built into FreeRDP, but some distributions may bundle this
+                    separately. libguac-client-rdp loads this plugin in order to support clipboard,
+                    as well. If this plugin could not be loaded, then clipboard support will not be
+                    available, and the reason will be logged.</para>
             </section>
             <section>
-                <title>Failed to load guac_rdpsnd plugin</title>
-                <para>In order to support sound, libguac-client-rdp builds a
-                    plugin for FreeRDP called "guac_rdpsnd" which must be loaded
-                    for sound to be available. If libguac-client-rdp cannot load
-                    this plugin, sound will not work, and the reason will be
-                    logged. A likely explanation is that libguac-client-rdp was
-                    built from source, and the directory specified for FreeRDP's
-                    installation location was incorrect.</para>
+                <title>Cannot create static channel "<replaceable>name</replaceable>": failed to
+                    load "guac-common-svc" plugin for FreeRDP</title>
+                <para>RDP provides support for much of its feature set through static virtual
+                    channels. Sound support, for example is provided through the "RDPSND" channel.
+                    Device redirection for printers and drives is provided through "RDPDR". To
+                    support these and other static virtual channels, libguac-client-rdp builds a
+                    plugin for FreeRDP called "guac-common-svc" which allows Guacamole to hook into
+                    the parts of FreeRDP that support virtual channels.</para>
+                <para>If libguac-client-rdp cannot load this plugin, support for any features which
+                    leverage static virtual channels will not work, and the reason will be logged. A
+                    likely explanation is that libguac-client-rdp was built from source, and the
+                    directory specified for FreeRDP's installation location was incorrect. For
+                    FreeRDP to be able to find plugins, those plugins must be placed in the
+                        <filename>freerdp2/</filename> subdirectory of whichever directory contains
+                    the <filename>libfreerdp2.so</filename> library.</para>
             </section>
             <section>
                 <title>Server requested unsupported clipboard data type</title>


### PR DESCRIPTION
This change updates the manual with respect to the FreeRDP 2.x support added through apache/guacamole-server#243. In particular:

* Notes warning that a particular feature is unavailable in an older version of FreeRDP have been removed (as only FreeRDP 2.x or above is now supported).
* Build output, build requirements, and error messages have been updated to reflect changes in log messages made via apache/guacamole-server#243.
* The new "nla-ext" security mode has been added, and the documentation of existing security modes has been clarified or expanded.
* The default security mode has been updated from "rdp" to "any".