### PR TITLE
GUACAMOLE-1501: Makefile: use `find` in a POSIX-compatible way.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,16 +33,16 @@ clean:
 	$(RM) -R build/
 
 # All files which the build depends on
-MD_FILES=$(shell find -path "./src/*" -name "*.md")
-RST_FILES=$(shell find -path "./src/*" -name "*.rst")
-PNG_FILES=$(shell find -path "./src/*" -name "*.png")
+MD_FILES=$(shell find "./src" -name "*.md")
+RST_FILES=$(shell find "./src" -name "*.rst")
+PNG_FILES=$(shell find "./src" -name "*.png")
 
 #
 # HTML manual build
 #
 
 html: build/html/index.html
-	
+
 build/html/index.html: $(PNG_FILES) $(RST_FILES) $(MD_FILES)
 	sphinx-build -b html -d build/doctrees src/ build/html
 


### PR DESCRIPTION
Instead of using -path, pass paths as regular arguments.  This is POSIX-compatible.

Without this, the `find` call fails on Mac OSX 10.15:

find: illegal option -- p
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]