### PR TITLE
GUACAMOLE-1293: Document protocol changes associated with sending messages to the client.

### DIFF
--- a/src/guacamole-protocol.md
+++ b/src/guacamole-protocol.md
@@ -87,6 +87,12 @@ parameter.
 
 Valid protocol versions are as follows:
 
+`VERSION_1_5_0`
+: Protocol version 1.5.0 introduced two new instructions - the `msg`
+  instruction, which is used to send arbitrary messages to the client, and
+  the `name` handshake instruction, which allows the client to set the
+  human-readable name of the user joining a connection.
+
 `VERSION_1_3_0`
 : Protocol version 1.3.0 introduced the `require` instruction, used by the
   server to indicate that the client must provide additional arguments (such
@@ -138,6 +144,9 @@ The following are valid instructions during the handshake:
 `image`
 : The image formats that the client supports, in order of preference. The
   client in the example above is supporting both PNG and JPEG.
+
+`name`
+: The human-readable name of the user joining the connection.
 
 `timezone`
 : The timezone of the client, in IANA zone key format. More information on

--- a/src/protocol-reference.rst
+++ b/src/protocol-reference.rst
@@ -1230,3 +1230,24 @@ human-readable way.
     The client is already using too many resources. Existing resources must be
     freed before further requests are allowed.
 
+Message Codes
+-------------
+
+The `msg` instruction must have at least one numeric argument that the client
+then uses to interpret the message and determine what action, if any, it
+should take based on the message. The following numeric codes are currently
+implemented for this instruction.
+
+1 (``USER_JOINED``)
+    Notifies the owner of a connection that another user has joined the
+    connection. This message is expected to include two additional
+    arguments: the guacd-generated UUID of the user who is joining the
+    connection, and the arbitrary name of the user provided by the
+    client during the handshake.
+
+2 (``USER_LEFT``)
+    Notifies the owner of a connection that another user has left the
+    connection. This message is expected to include two additional
+    arguments: the guacd-generated UUID of the user who is leaving the
+    connection, and the arbitrary name of the user provided by the
+    client during the handshake.

--- a/src/protocol-reference.rst
+++ b/src/protocol-reference.rst
@@ -713,6 +713,23 @@ Streaming instructions
     :arg string filename:
         The name of the file, as it would be saved on a filesystem.
 
+.. guac:instruction:: msg
+    :sent-by: server
+    :phase: interactive
+
+    Sends a message from the server (guacd) to the client. The nature of these
+    messages is intentionally broad and flexible - the message must include
+    a numeric code that the client understands and can act on, and may also
+    any number of arguments that can be used by the client in association
+    with the message.
+
+    :arg integer msg:
+        A numeric value indicating the message that is being passed to the client.
+
+    :arg string args:
+        Any number of arguments associated with the message that is being sent
+        to the client.
+
 .. guac:instruction:: pipe
     :sent-by: client,server
     :phase: interactive
@@ -897,6 +914,16 @@ Client handshake instructions
     It is expected that the supported mimetypes will include at least
     "image/png" and "image/jpeg", and the server *may* safely assume that these
     mimetypes are supported, even if they are absent from the handshake.
+
+.. guac:instruction:: name
+    :sent-by: client
+    :phase: handshake
+
+    Specifies the human-readable name of the user joining a connection. A
+    single, string value is expected for this, and guacd does not expect
+    or require that this value be unique among other users connected to
+    the server or connection. The type of name provided is completely up
+    to the client implementation.
 
 .. guac:instruction:: select
     :sent-by: client


### PR DESCRIPTION
This PR documents the protocol changes that were made when implementing the notification of connection join and leave events, notably the changes to the client -> server handshake, and the msg instruction.