### PR TITLE
GUACAMOLE-1727: Fix link to PostgreSQL JDBC downloads.

### DIFF
--- a/src/jdbc-auth.md
+++ b/src/jdbc-auth.md
@@ -83,7 +83,7 @@ If using the JDBC driver from MySQL, the required `.jar` will be within a
 * - SQL schema scripts
   - `postgresql/schema/`
 * - JDBC driver
-  - [PostgreSQL JDBC Driver](https://jdbc.postgresql.org/download.html#current)
+  - [PostgreSQL JDBC Driver](https://jdbc.postgresql.org/download/#latest-versions)
 :::
 ::::
 


### PR DESCRIPTION
This change reapplies the same commits from #200 against `staging/1.5.2`.