### PR TITLE
GUACAMOLE-1787: Link to an existing page that documents X11 KeySyms.

### DIFF
--- a/src/protocol-reference.rst
+++ b/src/protocol-reference.rst
@@ -1108,7 +1108,7 @@ Input/Event instructions
     Sends the specified key press or release event.
 
     :arg integer keysym:
-        The `X11 keysym <http://www.x.org/wiki/KeySyms>`__ of the key being
+        The `X11 keysym <https://www.x.org/releases/X11R7.6/doc/xproto/x11protocol.html#keysym_encoding>`__ of the key being
         pressed or released.
 
     :arg integer pressed:


### PR DESCRIPTION
The [old page](https://web.archive.org/web/20120729032231/http://www.x.org/wiki/KeySyms) that it used to link to looked to be describing a change in how KeySyms worked, though it didn't have a lot of background. 

This [new page](https://www.x.org/releases/X11R7.6/doc/xproto/x11protocol.html#keysym_encoding) has more general information about KeySyms, including big tables of examples. It seems to me like this new page will be more helpful to reference here.