### PR TITLE
GUACAMOLE-1834: Include required '%s' for extlinks configuration.

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -47,7 +47,7 @@ extensions = [
 
 # Allow shorthand notation for JIRA issue links
 extlinks = {
-    'jira': ( 'https://issues.apache.org/jira/browse/%s', '')
+    'jira': ( 'https://issues.apache.org/jira/browse/%s', '%s')
 }
 
 templates_path = [ '_templates' ]


### PR DESCRIPTION
This is required as of Sphinx 6.0 and the build now fails without this. Original warning from old versions of Sphinx was:

    WARNING: extlinks: Sphinx-6.0 will require a caption string to
    contain exactly one '%s' and all other '%' need to be escaped as
    '%%'.