### PR TITLE
GUACAMOLE-990: Fix auth-ban extension doc link in index.

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -49,7 +49,7 @@ openid-auth
 saml-auth
 radius-auth
 adhoc-connections
-ban-auth
+auth-ban
 using-guacamole
 recording-playback
 administration


### PR DESCRIPTION
Noticed this issue when building other changes. Fixed now.

```
sphinx-build -b html -d build/doctrees src/ build/html
Running Sphinx v7.0.1
loading pickled environment... done
myst v4.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'colon_fence', 'smartquotes', 'substitution', 'replacements', 'deflist'}, disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={version: ...}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 1 source files that are out of date
updating environment: 0 added, 2 changed, 0 removed
reading sources... [100%] index                                                                                                                                                        
/home/ubuntu/workspace/guacamole-manual/src/index.md:30: WARNING: toctree contains reference to nonexisting document 'ban-auth' <- here
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/ubuntu/workspace/guacamole-manual/src/auth-ban.md: WARNING: document isn't included in any toctree <- this
done
preparing documents... done
writing output... [100%] index                                                                                                                                                         
generating indices... genindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 2 warnings.

The HTML pages are in build/html.
```