### PR TITLE
GUACAMOLE-2038: Document configuring outbound IPv6 connections from guacamole

### DIFF
--- a/src/guacamole-docker.md
+++ b/src/guacamole-docker.md
@@ -182,8 +182,8 @@ not be able to start up, and you will see an error.
 
 :::{note}
 This section only applies to traffic originated by Gucamole Client,
-e.g. connections from Guacamole Client to guacd, or to authentication
-servers.
+e.g. connections from Guacamole Client to guacd, the database, or to
+authentication servers.
 
 Guacamole Client does not connect directly to RDP, VNC or SSH servers,
 this is done by guacd.


### PR DESCRIPTION
This adds a documentation section for how to configure tomcat to prefer outbound IPv6 connections, which is useful in an IPv6-only environment.

NOTE: This PR should not be merged before #267 is merged, since there's a link to a chapter added in that PR, about configuring guacd for IPv6, which must be done when enabling this.