### PR TITLE
GUACAMOLE-2039: Explain that other auth methods are possible in docker

### DIFF
--- a/src/guacamole-docker.md
+++ b/src/guacamole-docker.md
@@ -842,6 +842,21 @@ unusable if your authenticator app does not support setting these parameters.
 
 (guacamole-docker-history-recording-storage)=
 
+### Other authentication methods
+
+In addition to the authentication methods explicitly documented above, the
+guacamole-server Docker image is built containing multiple other authentication
+extensions, such as [](openid-auth).
+
+These authentication connections can also be configured using environment
+properties, similar to the examples above. There is nothing special about the
+authentication methods listed above that makes them work with the Docker
+image.
+
+Environment properties are discussed in [](configuring-guacamole), but to
+give a brief example, the `openid-authorization-endpoint` property can be set
+by setting the `OPENID_AUTHORIZATION_ENDPOINT` environment variable.
+
 ### History Recording Storage Extension
 
 The extension that enables viewing historical recordings from within the


### PR DESCRIPTION
Explicitly explain that other authentication methods, even such that are not explicitly documented as supported under Docker, are also possible to use, such as OpenID connect.

Technically, this doesn't add any new information since the "Configuring Guacamole when using Docker" section already explains using environment properties, but it does make this information easier to find.