### PR TITLE
GUACAMOLE-2206: Add documentation for admin restriction property.

### DIFF
--- a/src/auth-restrict.md.j2
+++ b/src/auth-restrict.md.j2
@@ -32,6 +32,13 @@ Installing/Enabling support for advanced restrictions
 
 {{ ext.install('RESTRICT', 'guacamole-auth-restrict') }}
 
+Configuration (optional)
+------------------------
+
+{% call ext.config('restrict') %}
+{{ ext.nothingRequired() }}
+{% endcall %}
+
 (completing-auth-restrict-install)=
 
 Completing installation

--- a/src/include/restrict.properties.in
+++ b/src/include/restrict.properties.in
@@ -1,0 +1,9 @@
+#
+# Whether or not login restrictions configured with this extension should
+# apply to Guacamole accounts with the System Administration permission.
+# If set to false, the default, admin accounts will be exempt from login
+# restrictions (though connection-specific limits will still apply). If
+# set to true, login restrictions applied to admin accounts, either directly
+# or via group membership will be enforced.
+#
+restrict-admin-accounts: false


### PR DESCRIPTION
This documents the property added by apache/guacamole-client#1157, enabling login restrictions to apply to admin accounts.